### PR TITLE
Migrate paraswap plugin with unit tests to new repository

### DIFF
--- a/contracts/adapters/BaseParaSwapAdapter.sol
+++ b/contracts/adapters/BaseParaSwapAdapter.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.10;
+
+import {IERC20} from '../dependencies/openzeppelin/contracts/IERC20.sol';
+import {IERC20Detailed} from '../dependencies/openzeppelin/contracts/IERC20Detailed.sol';
+import {SafeERC20} from '../dependencies/openzeppelin/contracts/SafeERC20.sol';
+import {Ownable} from '../dependencies/openzeppelin/contracts/Ownable.sol';
+import {IPoolAddressesProvider} from '../interfaces/IPoolAddressesProvider.sol';
+import {DataTypes} from '../protocol/libraries/types/DataTypes.sol';
+import {IPriceOracleGetter} from '../interfaces/IPriceOracleGetter.sol';
+import {IERC20WithPermit} from '../interfaces/IERC20WithPermit.sol';
+import {FlashLoanReceiverBase} from '../flashloan/base/FlashLoanReceiverBase.sol';
+
+/**
+ * @title BaseParaSwapAdapter
+ * @notice Utility functions for adapters using ParaSwap
+ */
+abstract contract BaseParaSwapAdapter is FlashLoanReceiverBase, Ownable {
+  using SafeERC20 for IERC20;
+  using SafeERC20 for IERC20Detailed;
+  using SafeERC20 for IERC20WithPermit;
+
+  struct PermitSignature {
+    uint256 amount;
+    uint256 deadline;
+    uint8 v;
+    bytes32 r;
+    bytes32 s;
+  }
+
+  // Max slippage percent allowed
+  uint256 public constant MAX_SLIPPAGE_PERCENT = 3000; // 30%
+
+  IPriceOracleGetter public immutable ORACLE;
+
+  event Swapped(
+    address indexed fromAsset,
+    address indexed toAsset,
+    uint256 fromAmount,
+    uint256 receivedAmount
+  );
+
+  constructor(IPoolAddressesProvider addressesProvider) FlashLoanReceiverBase(addressesProvider) {
+    ORACLE = IPriceOracleGetter(addressesProvider.getPriceOracle());
+  }
+
+  /**
+   * @dev Get the price of the asset from the oracle denominated in eth
+   * @param asset address
+   * @return eth price for the asset
+   */
+  function _getPrice(address asset) internal view returns (uint256) {
+    return ORACLE.getAssetPrice(asset);
+  }
+
+  /**
+   * @dev Get the decimals of an asset
+   * @return number of decimals of the asset
+   */
+  function _getDecimals(IERC20Detailed asset) internal view returns (uint8) {
+    uint8 decimals = asset.decimals();
+    // Ensure 10**decimals won't overflow a uint256
+    require(decimals <= 77, 'TOO_MANY_DECIMALS_ON_TOKEN');
+    return decimals;
+  }
+
+  /**
+   * @dev Get the reserve data associated to the asset
+   * @return DataTypes.ReserveData memory
+   */
+  function _getReserveData(address asset) internal view returns (DataTypes.ReserveData memory) {
+    return POOL.getReserveData(asset);
+  }
+
+  /**
+   * @dev Pull the aTokens from the user
+   * @param reserve address of the asset
+   * @param reserveAToken address of the aToken of the reserve
+   * @param user address
+   * @param amount of tokens to be transferred to the contract
+   * @param permitSignature struct containing the permit signature
+   */
+  function _pullATokenAndWithdraw(
+    address reserve,
+    IERC20WithPermit reserveAToken,
+    address user,
+    uint256 amount,
+    PermitSignature memory permitSignature
+  ) internal {
+    // If deadline is set to zero, assume there is no signature for permit
+    if (permitSignature.deadline != 0) {
+      reserveAToken.permit(
+        user,
+        address(this),
+        permitSignature.amount,
+        permitSignature.deadline,
+        permitSignature.v,
+        permitSignature.r,
+        permitSignature.s
+      );
+    }
+
+    // transfer from user to adapter
+    reserveAToken.safeTransferFrom(user, address(this), amount);
+
+    // withdraw reserve
+    require(POOL.withdraw(reserve, amount, address(this)) == amount, 'UNEXPECTED_AMOUNT_WITHDRAWN');
+  }
+
+  /**
+   * @dev Emergency rescue for token stucked on this contract, as failsafe mechanism
+   * - Funds should never remain in this contract more time than during transactions
+   * - Only callable by the owner
+   */
+  function rescueTokens(IERC20 token) external onlyOwner {
+    token.safeTransfer(owner(), token.balanceOf(address(this)));
+  }
+}

--- a/contracts/adapters/BaseParaSwapSellAdapter.sol
+++ b/contracts/adapters/BaseParaSwapSellAdapter.sol
@@ -63,7 +63,7 @@ abstract contract BaseParaSwapSellAdapter is BaseParaSwapAdapter {
       expectedMinAmountOut = expectedMinAmountOut.percentMul(
         PercentageMath.PERCENTAGE_FACTOR - MAX_SLIPPAGE_PERCENT
       );
-      require(expectedMinAmountOut <= minAmountToReceive, 'MIN_AMOUNT_EXCEEDS_MAX_SLIPPAGE');
+      require(expectedMinAmountOut >= minAmountToReceive, 'MIN_AMOUNT_EXCEEDS_MAX_SLIPPAGE');
     }
 
     uint256 balanceBeforeAssetFrom = assetToSwapFrom.balanceOf(address(this));

--- a/contracts/adapters/BaseParaSwapSellAdapter.sol
+++ b/contracts/adapters/BaseParaSwapSellAdapter.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.10;
+
+import {BaseParaSwapAdapter} from './BaseParaSwapAdapter.sol';
+import {PercentageMath} from '../protocol/libraries/math/PercentageMath.sol';
+import {IParaSwapAugustus} from '../interfaces/IParaSwapAugustus.sol';
+import {IParaSwapAugustusRegistry} from '../interfaces/IParaSwapAugustusRegistry.sol';
+import {IPoolAddressesProvider} from '../interfaces/IPoolAddressesProvider.sol';
+import {IERC20} from '../dependencies/openzeppelin/contracts/IERC20.sol';
+import {IERC20Detailed} from '../dependencies/openzeppelin/contracts/IERC20Detailed.sol';
+import {SafeERC20} from '../dependencies/openzeppelin/contracts/SafeERC20.sol';
+
+/**
+ * @title BaseParaSwapSellAdapter
+ * @notice Implements the logic for selling tokens on ParaSwap
+ */
+abstract contract BaseParaSwapSellAdapter is BaseParaSwapAdapter {
+  using PercentageMath for uint256;
+  using SafeERC20 for IERC20;
+
+  IParaSwapAugustusRegistry public immutable AUGUSTUS_REGISTRY;
+
+  constructor(
+    IPoolAddressesProvider addressesProvider,
+    IParaSwapAugustusRegistry augustusRegistry
+  ) BaseParaSwapAdapter(addressesProvider) {
+    // Do something on Augustus registry to check the right contract was passed
+    require(!augustusRegistry.isValidAugustus(address(0)), 'INVALID_AUGUSTUS_REGISTRY');
+    AUGUSTUS_REGISTRY = augustusRegistry;
+  }
+
+  /**
+   * @dev Swaps a token for another using ParaSwap
+   * @param fromAmountOffset Offset of fromAmount in Augustus calldata if it should be overwritten, otherwise 0
+   * @param swapCalldata Calldata for ParaSwap's AugustusSwapper contract
+   * @param augustus Address of ParaSwap's AugustusSwapper contract
+   * @param assetToSwapFrom Address of the asset to be swapped from
+   * @param assetToSwapTo Address of the asset to be swapped to
+   * @param amountToSwap Amount to be swapped
+   * @param minAmountToReceive Minimum amount to be received from the swap
+   * @return amountReceived The amount received from the swap
+   */
+  function _sellOnParaSwap(
+    uint256 fromAmountOffset,
+    bytes memory swapCalldata,
+    IParaSwapAugustus augustus,
+    IERC20 assetToSwapFrom,
+    IERC20 assetToSwapTo,
+    uint256 amountToSwap,
+    uint256 minAmountToReceive
+  ) internal returns (uint256 amountReceived) {
+    require(AUGUSTUS_REGISTRY.isValidAugustus(address(augustus)), 'INVALID_AUGUSTUS');
+
+    {
+      uint256 fromAssetDecimals = _getDecimals(IERC20Detailed(address(assetToSwapFrom)));
+      uint256 toAssetDecimals = _getDecimals(IERC20Detailed(address(assetToSwapTo)));
+
+      uint256 fromAssetPrice = _getPrice(address(assetToSwapFrom));
+      uint256 toAssetPrice = _getPrice(address(assetToSwapTo));
+
+      uint256 expectedMinAmountOut = (amountToSwap * (fromAssetPrice * (10 ** toAssetDecimals))) /
+        (toAssetPrice * (10 ** fromAssetDecimals));
+      expectedMinAmountOut = expectedMinAmountOut.percentMul(
+        PercentageMath.PERCENTAGE_FACTOR - MAX_SLIPPAGE_PERCENT
+      );
+      require(expectedMinAmountOut <= minAmountToReceive, 'MIN_AMOUNT_EXCEEDS_MAX_SLIPPAGE');
+    }
+
+    uint256 balanceBeforeAssetFrom = assetToSwapFrom.balanceOf(address(this));
+    require(balanceBeforeAssetFrom >= amountToSwap, 'INSUFFICIENT_BALANCE_BEFORE_SWAP');
+    uint256 balanceBeforeAssetTo = assetToSwapTo.balanceOf(address(this));
+
+    address tokenTransferProxy = augustus.getTokenTransferProxy();
+    assetToSwapFrom.safeApprove(tokenTransferProxy, 0);
+    assetToSwapFrom.safeApprove(tokenTransferProxy, amountToSwap);
+
+    if (fromAmountOffset != 0) {
+      // Ensure 256 bit (32 bytes) fromAmount value is within bounds of the
+      // calldata, not overlapping with the first 4 bytes (function selector).
+      require(
+        fromAmountOffset >= 4 && fromAmountOffset <= swapCalldata.length - 32,
+        'FROM_AMOUNT_OFFSET_OUT_OF_RANGE'
+      );
+      // Overwrite the fromAmount with the correct amount for the swap.
+      // In memory, swapCalldata consists of a 256 bit length field, followed by
+      // the actual bytes data, that is why 32 is added to the byte offset.
+      assembly {
+        mstore(add(swapCalldata, add(fromAmountOffset, 32)), amountToSwap)
+      }
+    }
+    (bool success, ) = address(augustus).call(swapCalldata);
+    if (!success) {
+      // Copy revert reason from call
+      assembly {
+        returndatacopy(0, 0, returndatasize())
+        revert(0, returndatasize())
+      }
+    }
+    require(
+      assetToSwapFrom.balanceOf(address(this)) == balanceBeforeAssetFrom - amountToSwap,
+      'WRONG_BALANCE_AFTER_SWAP'
+    );
+    amountReceived = assetToSwapTo.balanceOf(address(this)) - balanceBeforeAssetTo;
+    require(amountReceived >= minAmountToReceive, 'INSUFFICIENT_AMOUNT_RECEIVED');
+
+    emit Swapped(address(assetToSwapFrom), address(assetToSwapTo), amountToSwap, amountReceived);
+  }
+}

--- a/contracts/adapters/ParaSwapLiquiditySwapAdapter.sol
+++ b/contracts/adapters/ParaSwapLiquiditySwapAdapter.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.10;
+
+import {SafeERC20} from '../dependencies/openzeppelin/contracts/SafeERC20.sol';
+import {BaseParaSwapSellAdapter} from './BaseParaSwapSellAdapter.sol';
+import {IPoolAddressesProvider} from '../interfaces/IPoolAddressesProvider.sol';
+import {IParaSwapAugustusRegistry} from '../interfaces/IParaSwapAugustusRegistry.sol';
+import {IERC20} from '../dependencies/openzeppelin/contracts/IERC20.sol';
+import {IERC20WithPermit} from '../interfaces/IERC20WithPermit.sol';
+import {IParaSwapAugustus} from '../interfaces/IParaSwapAugustus.sol';
+import {console} from 'hardhat/console.sol';
+
+/**
+ * @title ParaSwapLiquiditySwapAdapter
+ * @notice Adapter to swap liquidity using ParaSwap.
+ */
+contract ParaSwapLiquiditySwapAdapter is BaseParaSwapSellAdapter {
+  using SafeERC20 for IERC20;
+
+  constructor(
+    IPoolAddressesProvider addressesProvider,
+    IParaSwapAugustusRegistry augustusRegistry
+  ) BaseParaSwapSellAdapter(addressesProvider, augustusRegistry) {}
+
+  /**
+   * @dev Swaps the received reserve amount from the flash loan into the asset specified in the params.
+   * The received funds from the swap are then deposited into the protocol on behalf of the user.
+   * The user should give this contract allowance to pull the ZTokens in order to withdraw the underlying asset and repay the flash loan.
+   * @param assets Address of the underlying asset to be swapped from
+   * @param amounts Amount of the flash loan i.e. maximum amount to swap
+   * @param premiums Fee of the flash loan
+   * @param initiator Account that initiated the flash loan
+   * @param params Additional variadic field to include extra params. Expected parameters:
+   *   address assetToSwapTo Address of the underlying asset to be swapped to and deposited
+   *   uint256 minAmountToReceive Min amount to be received from the swap
+   *   uint256 swapAllBalanceOffset Set to offset of fromAmount in Augustus calldata if wanting to swap all balance, otherwise 0
+   *   bytes swapCalldata Calldata for ParaSwap's AugustusSwapper contract
+   *   address augustus Address of ParaSwap's AugustusSwapper contract
+   *   PermitSignature permitParams Struct containing the permit signatures, set to all zeroes if not used
+   */
+  function executeOperation(
+    address[] calldata assets,
+    uint256[] calldata amounts,
+    uint256[] calldata premiums,
+    address initiator,
+    bytes calldata params
+  ) external override returns (bool) {
+    require(msg.sender == address(POOL), 'CALLER_MUST_BE_POOL');
+
+    require(
+      assets.length == 1 && amounts.length == 1 && premiums.length == 1,
+      'FLASHLOAN_MULTIPLE_ASSETS_NOT_SUPPORTED'
+    );
+
+    uint256 flashLoanAmount = amounts[0];
+    uint256 premium = premiums[0];
+    address initiatorLocal = initiator;
+    IERC20 assetToSwapFrom = IERC20(assets[0]);
+    (
+      IERC20 assetToSwapTo,
+      uint256 minAmountToReceive,
+      uint256 swapAllBalanceOffset,
+      bytes memory swapCalldata,
+      IParaSwapAugustus augustus,
+      PermitSignature memory permitParams
+    ) = abi.decode(params, (IERC20, uint256, uint256, bytes, IParaSwapAugustus, PermitSignature));
+
+    _swapLiquidity(
+      swapAllBalanceOffset,
+      swapCalldata,
+      augustus,
+      permitParams,
+      flashLoanAmount,
+      premium,
+      initiatorLocal,
+      assetToSwapFrom,
+      assetToSwapTo,
+      minAmountToReceive
+    );
+
+    return true;
+  }
+
+  /**
+   * @dev Swaps an amount of an asset to another and deposits the new asset amount on behalf of the user without using a flash loan.
+   * This method can be used when the temporary transfer of the collateral asset to this contract does not affect the user position.
+   * The user should give this contract allowance to pull the ZTokens in order to withdraw the underlying asset and perform the swap.
+   * @param assetToSwapFrom Address of the underlying asset to be swapped from
+   * @param assetToSwapTo Address of the underlying asset to be swapped to and deposited
+   * @param amountToSwap Amount to be swapped, or maximum amount when swapping all balance
+   * @param minAmountToReceive Minimum amount to be received from the swap
+   * @param swapAllBalanceOffset Set to offset of fromAmount in Augustus calldata if wanting to swap all balance, otherwise 0
+   * @param swapCalldata Calldata for ParaSwap's AugustusSwapper contract
+   * @param augustus Address of ParaSwap's AugustusSwapper contract
+   * @param permitParams Struct containing the permit signatures, set to all zeroes if not used
+   */
+  function swapAndDeposit(
+    IERC20 assetToSwapFrom,
+    IERC20 assetToSwapTo,
+    uint256 amountToSwap,
+    uint256 minAmountToReceive,
+    uint256 swapAllBalanceOffset,
+    bytes calldata swapCalldata,
+    IParaSwapAugustus augustus,
+    PermitSignature calldata permitParams
+  ) external {
+    IERC20WithPermit aToken = IERC20WithPermit(
+      _getReserveData(address(assetToSwapFrom)).aTokenAddress
+    );
+
+    if (swapAllBalanceOffset != 0) {
+      uint256 balance = aToken.balanceOf(msg.sender);
+      require(balance <= amountToSwap, 'INSUFFICIENT_AMOUNT_TO_SWAP');
+      amountToSwap = balance;
+    }
+
+    _pullATokenAndWithdraw(
+      address(assetToSwapFrom),
+      aToken,
+      msg.sender,
+      amountToSwap,
+      permitParams
+    );
+
+    uint256 amountReceived = _sellOnParaSwap(
+      swapAllBalanceOffset,
+      swapCalldata,
+      augustus,
+      assetToSwapFrom,
+      assetToSwapTo,
+      amountToSwap,
+      minAmountToReceive
+    );
+
+    IERC20(address(assetToSwapTo)).safeApprove(address(POOL), 0);
+    IERC20(address(assetToSwapTo)).safeApprove(address(POOL), amountReceived);
+    POOL.deposit(address(assetToSwapTo), amountReceived, msg.sender, 0);
+  }
+
+  /**
+   * @dev Swaps an amount of an asset to another and deposits the funds on behalf of the initiator.
+   * @param swapAllBalanceOffset Set to offset of fromAmount in Augustus calldata if wanting to swap all balance, otherwise 0
+   * @param swapCalldata Calldata for ParaSwap's AugustusSwapper contract
+   * @param augustus Address of ParaSwap's AugustusSwapper contract
+   * @param permitParams Struct containing the permit signatures, set to all zeroes if not used
+   * @param flashLoanAmount Amount of the flash loan i.e. maximum amount to swap
+   * @param premium Fee of the flash loan
+   * @param initiator Account that initiated the flash loan
+   * @param assetToSwapFrom Address of the underyling asset to be swapped from
+   * @param assetToSwapTo Address of the underlying asset to be swapped to and deposited
+   * @param minAmountToReceive Min amount to be received from the swap
+   */
+  function _swapLiquidity(
+    uint256 swapAllBalanceOffset,
+    bytes memory swapCalldata,
+    IParaSwapAugustus augustus,
+    PermitSignature memory permitParams,
+    uint256 flashLoanAmount,
+    uint256 premium,
+    address initiator,
+    IERC20 assetToSwapFrom,
+    IERC20 assetToSwapTo,
+    uint256 minAmountToReceive
+  ) internal {
+    IERC20WithPermit aToken = IERC20WithPermit(
+      _getReserveData(address(assetToSwapFrom)).aTokenAddress
+    );
+    uint256 amountToSwap = flashLoanAmount;
+
+    uint256 balance = aToken.balanceOf(initiator);
+    if (swapAllBalanceOffset != 0) {
+      uint256 balanceToSwap = balance - premium;
+      require(balanceToSwap <= amountToSwap, 'INSUFFICIENT_AMOUNT_TO_SWAP');
+      amountToSwap = balanceToSwap;
+    } else {
+      require(balance >= amountToSwap + premium, 'INSUFFICIENT_ATOKEN_BALANCE');
+    }
+
+    uint256 amountReceived = _sellOnParaSwap(
+      swapAllBalanceOffset,
+      swapCalldata,
+      augustus,
+      assetToSwapFrom,
+      assetToSwapTo,
+      amountToSwap,
+      minAmountToReceive
+    );
+
+    IERC20(address(assetToSwapTo)).safeApprove(address(POOL), 0);
+    IERC20(address(assetToSwapTo)).safeApprove(address(POOL), amountReceived);
+    POOL.deposit(address(assetToSwapTo), amountReceived, initiator, 0);
+
+    _pullATokenAndWithdraw(
+      address(assetToSwapFrom),
+      aToken,
+      initiator,
+      amountToSwap + premium,
+      permitParams
+    );
+
+    assetToSwapFrom.safeApprove(address(POOL), 0);
+    assetToSwapFrom.safeApprove(address(POOL), flashLoanAmount + premium);
+  }
+}

--- a/contracts/interfaces/IParaSwapAugustus.sol
+++ b/contracts/interfaces/IParaSwapAugustus.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity ^0.8.10;
+pragma experimental ABIEncoderV2;
+
+interface IParaSwapAugustus {
+  function getTokenTransferProxy() external view returns (address);
+}

--- a/contracts/interfaces/IParaSwapAugustusRegistry.sol
+++ b/contracts/interfaces/IParaSwapAugustusRegistry.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity ^0.8.10;
+pragma experimental ABIEncoderV2;
+
+interface IParaSwapAugustusRegistry {
+  function isValidAugustus(address augustus) external view returns (bool);
+
+  function getAugustusAddresses() external view returns (address[] memory);
+}

--- a/contracts/mocks/swap/MockParaSwapAugustus.sol
+++ b/contracts/mocks/swap/MockParaSwapAugustus.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import {IParaSwapAugustus} from '../../interfaces/IParaSwapAugustus.sol';
+import {MockParaSwapTokenTransferProxy} from './MockParaSwapTokenTransferProxy.sol';
+import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
+import {MintableERC20} from '../tokens/MintableERC20.sol';
+
+contract MockParaSwapAugustus is IParaSwapAugustus {
+  MockParaSwapTokenTransferProxy immutable TOKEN_TRANSFER_PROXY;
+  bool _expectingSwap;
+  address _expectedFromToken;
+  address _expectedToToken;
+  uint256 _expectedFromAmountMin;
+  uint256 _expectedFromAmountMax;
+  uint256 _receivedAmount;
+
+  constructor() {
+    TOKEN_TRANSFER_PROXY = new MockParaSwapTokenTransferProxy();
+  }
+
+  function getTokenTransferProxy() external view override returns (address) {
+    return address(TOKEN_TRANSFER_PROXY);
+  }
+
+  function expectSwap(
+    address fromToken,
+    address toToken,
+    uint256 fromAmountMin,
+    uint256 fromAmountMax,
+    uint256 receivedAmount
+  ) external {
+    _expectingSwap = true;
+    _expectedFromToken = fromToken;
+    _expectedToToken = toToken;
+    _expectedFromAmountMin = fromAmountMin;
+    _expectedFromAmountMax = fromAmountMax;
+    _receivedAmount = receivedAmount;
+  }
+
+  function swap(
+    address fromToken,
+    address toToken,
+    uint256 fromAmount,
+    uint256 toAmount
+  ) external returns (uint256) {
+    // require(_expectingSwap, 'Not expecting swap');
+    // require(fromToken == _expectedFromToken, 'Unexpected from token');
+    // require(toToken == _expectedToToken, 'Unexpected to token');
+    // require(fromAmount >= _expectedFromAmountMin && fromAmount <= _expectedFromAmountMax, 'From amount out of range');
+    // require(_receivedAmount >= toAmount, 'Received amount of tokens are less than expected');
+    TOKEN_TRANSFER_PROXY.transferFrom(fromToken, msg.sender, address(this), fromAmount);
+    MintableERC20(toToken).mint(_receivedAmount);
+    IERC20(toToken).transfer(msg.sender, _receivedAmount);
+    _expectingSwap = false;
+    return _receivedAmount;
+  }
+}

--- a/contracts/mocks/swap/MockParaSwapAugustusRegistry.sol
+++ b/contracts/mocks/swap/MockParaSwapAugustusRegistry.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import {IParaSwapAugustusRegistry} from '../../interfaces/IParaSwapAugustusRegistry.sol';
+
+contract MockParaSwapAugustusRegistry is IParaSwapAugustusRegistry {
+  address immutable AUGUSTUS;
+
+  constructor(address augustus) {
+    AUGUSTUS = augustus;
+  }
+
+  function isValidAugustus(address augustus) external view override returns (bool) {
+    return augustus == AUGUSTUS;
+  }
+
+  function getAugustusAddresses() external view override returns (address[] memory) {
+    address[] memory augustusAddresses = new address[](1);
+    augustusAddresses[0] = AUGUSTUS;
+    return augustusAddresses;
+  }
+}

--- a/contracts/mocks/swap/MockParaSwapAugustusTestnet.sol
+++ b/contracts/mocks/swap/MockParaSwapAugustusTestnet.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import {IParaSwapAugustus} from '../../interfaces/IParaSwapAugustus.sol';
+import {MockParaSwapTokenTransferProxy} from './MockParaSwapTokenTransferProxy.sol';
+import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
+import {MintableERC20} from '../tokens/MintableERC20.sol';
+import {SafeMath} from '../../dependencies/openzeppelin/contracts/SafeMath.sol';
+import {IFaucetInteractor} from '../../interfaces/IFaucetInteractor.sol';
+
+contract MockParaSwapAugustusTestnet is IParaSwapAugustus {
+  using SafeMath for uint256;
+
+  MockParaSwapTokenTransferProxy immutable TOKEN_TRANSFER_PROXY;
+  string constant INVALID_SWAP_AMOUNT = 'amount and msg.value mismatch';
+  address constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+  mapping(address => uint256) private _tokenPricesInETH;
+  mapping(address => bool) private _isMintable;
+  IFaucetInteractor internal faucetInteractor;
+
+  event TokenPricesSet(address[] tokens, uint256[] prices, bool[] isMintable);
+  event Swaped(address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut);
+
+  bool _expectingSwap;
+  address _expectedFromToken;
+  address _expectedToToken;
+  uint256 _expectedFromAmountMin;
+  uint256 _expectedFromAmountMax;
+  uint256 _receivedAmount;
+
+  constructor(IFaucetInteractor _faucetInteractor) {
+    TOKEN_TRANSFER_PROXY = new MockParaSwapTokenTransferProxy();
+    faucetInteractor = _faucetInteractor;
+  }
+
+  function getTokenTransferProxy() external view override returns (address) {
+    return address(TOKEN_TRANSFER_PROXY);
+  }
+
+  function getTokenPrice(address token) external view returns (uint256) {
+    require(_tokenPricesInETH[token] > 0, 'Price not set');
+    return _tokenPricesInETH[token];
+  }
+
+  function expectSwap(
+    address fromToken,
+    address toToken,
+    uint256 fromAmountMin,
+    uint256 fromAmountMax,
+    uint256 receivedAmount
+  ) external {
+    _expectingSwap = true;
+    _expectedFromToken = fromToken;
+    _expectedToToken = toToken;
+    _expectedFromAmountMin = fromAmountMin;
+    _expectedFromAmountMax = fromAmountMax;
+    _receivedAmount = receivedAmount;
+  }
+
+  function swap(
+    address fromToken,
+    address toToken,
+    uint256 fromAmount,
+    uint256 toAmount
+  ) external returns (uint256) {
+    require(
+      _tokenPricesInETH[fromToken] > 0 && _tokenPricesInETH[toToken] > 0,
+      'Token price not set'
+    );
+
+    uint8 fromDecimals = MintableERC20(fromToken).decimals();
+    uint8 toDecimals = MintableERC20(toToken).decimals();
+
+    uint256 receivedAmount = calculateReceivedAmount(
+      fromAmount,
+      _tokenPricesInETH[fromToken],
+      _tokenPricesInETH[toToken],
+      fromDecimals,
+      toDecimals
+    );
+
+    TOKEN_TRANSFER_PROXY.transferFrom(fromToken, msg.sender, address(this), fromAmount);
+    if (_isMintable[toToken]) {
+      faucetInteractor.allowlistMintSingle(toToken, receivedAmount);
+    }
+    IERC20(toToken).transfer(msg.sender, receivedAmount);
+    _expectingSwap = false;
+
+    emit Swaped(fromToken, toToken, fromAmount, receivedAmount);
+    return receivedAmount;
+  }
+
+  function swapExactTokensForTokens(
+    uint256 amountIn,
+    uint256 amountOut,
+    address tokenIn,
+    address tokenOut
+  ) external payable returns (uint256) {
+    if (tokenIn == NATIVE_TOKEN) {
+      require(msg.value == amountIn, INVALID_SWAP_AMOUNT);
+    } else {
+      TOKEN_TRANSFER_PROXY.transferFrom(tokenIn, msg.sender, address(this), amountIn);
+    }
+
+    if (_isMintable[tokenOut]) {
+      faucetInteractor.allowlistMintSingle(tokenOut, amountOut);
+    }
+    IERC20(tokenOut).transfer(msg.sender, amountOut);
+    _expectingSwap = false;
+
+    emit Swaped(tokenIn, tokenOut, amountIn, amountOut);
+    return amountOut;
+  }
+
+  /**
+   * @notice Sets the prices and mintable status for multiple tokens
+   * @param tokens Array of token addresses to set prices for
+   * @param pricesInETH Array of prices in ETH for each token (with 18 decimals)
+   * @param isMintable Array of booleans indicating if each token can be minted
+   * @dev All input arrays must be the same length
+   * @dev Token addresses cannot be zero address
+   * @dev Prices must be greater than 0
+   */
+  function setTokenPrices(
+    address[] calldata tokens,
+    uint256[] calldata pricesInETH,
+    bool[] calldata isMintable
+  ) external {
+    require(
+      tokens.length == pricesInETH.length && tokens.length == isMintable.length,
+      'Arrays length mismatch'
+    );
+
+    for (uint256 i = 0; i < tokens.length; i++) {
+      require(tokens[i] != address(0), 'Invalid token address');
+      _tokenPricesInETH[tokens[i]] = pricesInETH[i];
+      _isMintable[tokens[i]] = isMintable[i];
+    }
+
+    emit TokenPricesSet(tokens, pricesInETH, isMintable);
+  }
+
+  /**
+   * @notice Calculates the received amount when swapping between tokens
+   * @dev If tokens have different decimals, delegates to calculateDifferentDecimals
+   * @param amountIn The input amount of source token
+   * @param priceTokenIn The price of input token in ETH (18 decimals)
+   * @param priceTokenOut The price of output token in ETH (18 decimals)
+   * @param fromDecimals The decimal places of the input token
+   * @param toDecimals The decimal places of the output token
+   * @return The calculated output amount in target token decimals
+   */
+  function calculateReceivedAmount(
+    uint256 amountIn,
+    uint256 priceTokenIn,
+    uint256 priceTokenOut,
+    uint8 fromDecimals,
+    uint8 toDecimals
+  ) internal returns (uint256) {
+    if (fromDecimals != toDecimals) {
+      return
+        calculateDifferentDecimals(amountIn, priceTokenIn, priceTokenOut, fromDecimals, toDecimals);
+    }
+    return amountIn.mul(priceTokenIn).div(priceTokenOut);
+  }
+
+  /**
+   * @notice Calculates the received amount when swapping between tokens with different decimals
+   * @dev Normalizes token amounts to 18 decimals for calculation, then adjusts back to target decimals
+   * @param amountIn The input amount of source token
+   * @param priceTokenIn The price of input token in ETH (18 decimals)
+   * @param priceTokenOut The price of output token in ETH (18 decimals)
+   * @param fromDecimals The decimal places of the input token
+   * @param toDecimals The decimal places of the output token
+   * @return The calculated output amount in target token decimals
+   */
+  function calculateDifferentDecimals(
+    uint256 amountIn,
+    uint256 priceTokenIn,
+    uint256 priceTokenOut,
+    uint8 fromDecimals,
+    uint8 toDecimals
+  ) internal returns (uint256) {
+    uint256 normalizedAmount = amountIn;
+    if (fromDecimals < 18) {
+      uint256 decimalsDifference = 18 - fromDecimals;
+      normalizedAmount = amountIn.mul(10 ** decimalsDifference);
+    }
+
+    uint256 transferAmount = normalizedAmount.mul(priceTokenIn).div(priceTokenOut);
+
+    uint256 finalAmount = transferAmount;
+    if (toDecimals < 18) {
+      uint256 decimalsDifference = 18 - toDecimals;
+      finalAmount = transferAmount.div(10 ** decimalsDifference);
+    }
+
+    return finalAmount;
+  }
+
+  function getFaucetAddress() public view returns (address) {
+    return address(faucetInteractor);
+  }
+
+  // It is used to accept Native oken
+  receive() external payable {}
+}

--- a/contracts/mocks/swap/MockParaSwapTokenTransferProxy.sol
+++ b/contracts/mocks/swap/MockParaSwapTokenTransferProxy.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import {Ownable} from '../../dependencies/openzeppelin/contracts/Ownable.sol';
+import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
+
+contract MockParaSwapTokenTransferProxy is Ownable {
+  function transferFrom(
+    address token,
+    address from,
+    address to,
+    uint256 amount
+  ) external onlyOwner {
+    IERC20(token).transferFrom(from, to, amount);
+  }
+}

--- a/contracts/protocol/libraries/logic/FlashLoanLogic.sol
+++ b/contracts/protocol/libraries/logic/FlashLoanLogic.sol
@@ -17,6 +17,7 @@ import {DataTypes} from '../types/DataTypes.sol';
 import {ValidationLogic} from './ValidationLogic.sol';
 import {BorrowLogic} from './BorrowLogic.sol';
 import {ReserveLogic} from './ReserveLogic.sol';
+import {console} from 'hardhat/console.sol';
 
 /**
  * @title FlashLoanLogic library

--- a/contracts/protocol/tokenization/base/IncentivizedERC20.sol
+++ b/contracts/protocol/tokenization/base/IncentivizedERC20.sol
@@ -11,7 +11,6 @@ import {IAaveIncentivesController} from '../../../interfaces/IAaveIncentivesCont
 import {IPoolAddressesProvider} from '../../../interfaces/IPoolAddressesProvider.sol';
 import {IPool} from '../../../interfaces/IPool.sol';
 import {IACLManager} from '../../../interfaces/IACLManager.sol';
-import {console} from 'hardhat/console.sol';
 
 /**
  * @title IncentivizedERC20
@@ -147,12 +146,6 @@ abstract contract IncentivizedERC20 is Context, IERC20Detailed {
     uint256 amount
   ) external virtual override returns (bool) {
     uint128 castAmount = amount.toUint128();
-    console.log('sender:', sender);
-    console.log('recipient:', recipient);
-    console.log('amount:', amount);
-    console.log('castAmount:', castAmount);
-    console.log('allowance:', _allowances[sender][_msgSender()]);
-    console.log('allowance - castAmount:', _allowances[sender][_msgSender()] - castAmount);
     _approve(sender, _msgSender(), _allowances[sender][_msgSender()] - castAmount);
     _transfer(sender, recipient, castAmount);
     return true;

--- a/contracts/protocol/tokenization/base/IncentivizedERC20.sol
+++ b/contracts/protocol/tokenization/base/IncentivizedERC20.sol
@@ -11,6 +11,7 @@ import {IAaveIncentivesController} from '../../../interfaces/IAaveIncentivesCont
 import {IPoolAddressesProvider} from '../../../interfaces/IPoolAddressesProvider.sol';
 import {IPool} from '../../../interfaces/IPool.sol';
 import {IACLManager} from '../../../interfaces/IACLManager.sol';
+import {console} from 'hardhat/console.sol';
 
 /**
  * @title IncentivizedERC20
@@ -146,6 +147,12 @@ abstract contract IncentivizedERC20 is Context, IERC20Detailed {
     uint256 amount
   ) external virtual override returns (bool) {
     uint128 castAmount = amount.toUint128();
+    console.log('sender:', sender);
+    console.log('recipient:', recipient);
+    console.log('amount:', amount);
+    console.log('castAmount:', castAmount);
+    console.log('allowance:', _allowances[sender][_msgSender()]);
+    console.log('allowance - castAmount:', _allowances[sender][_msgSender()] - castAmount);
     _approve(sender, _msgSender(), _allowances[sender][_msgSender()] - castAmount);
     _transfer(sender, recipient, castAmount);
     return true;

--- a/helpers/contracts-helpers.ts
+++ b/helpers/contracts-helpers.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers';
+import { ethers, BigNumberish } from 'ethers';
 import { signTypedData_v4 } from 'eth-sig-util';
 import { fromRpcSig, ECDSASignature } from 'ethereumjs-util';
 import { tEthereumAddress, tStringTokenSmallUnits } from './types';
@@ -133,4 +133,36 @@ export const getProxyAdmin = async (proxyAddress: string) => {
     .decode(['address'], adminStorageSlot)
     .toString();
   return ethers.utils.getAddress(adminAddress);
+};
+
+export const buildParaSwapLiquiditySwapParams = (
+  assetToSwapTo: tEthereumAddress,
+  minAmountToReceive: BigNumberish,
+  swapAllBalanceOffset: BigNumberish,
+  swapCalldata: string | Buffer,
+  augustus: tEthereumAddress,
+  permitAmount: BigNumberish,
+  deadline: BigNumberish,
+  v: BigNumberish,
+  r: string | Buffer,
+  s: string | Buffer
+) => {
+  return ethers.utils.defaultAbiCoder.encode(
+    [
+      'address',
+      'uint256',
+      'uint256',
+      'bytes',
+      'address',
+      'tuple(uint256,uint256,uint8,bytes32,bytes32)',
+    ],
+    [
+      assetToSwapTo,
+      minAmountToReceive,
+      swapAllBalanceOffset,
+      swapCalldata,
+      augustus,
+      [permitAmount, deadline, v, r, s],
+    ]
+  );
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": ". ./setup-test-env.sh && TS_NODE_TRANSPILE_ONLY=1 hardhat test test-suites/*.spec.ts",
     "test-adapters": ". ./setup-test-env.sh && TS_NODE_TRANSPILE_ONLY=1 hardhat test test-suites/__setup.spec.ts test-suites/adapters.flashLiquidation.spec.ts",
     "test-oracles": ". ./setup-test-env.sh && TS_NODE_TRANSPILE_ONLY=1 hardhat test test-suites/__setup.spec.ts test-suites/wstzbu-oracle-gateway.spec.ts",
+    "test-paraswap": ". ./setup-test-env.sh && TS_NODE_TRANSPILE_ONLY=1 hardhat test test-suites/__setup.spec.ts test-suites/paraswapAdapters.liquiditySwap.spec",
     "test-scenarios": ". ./setup-test-env.sh && npx hardhat test test-suites/__setup.spec.ts test-suites/scenario.spec.ts",
     "test-l2pool": ". ./setup-test-env.sh && npx hardhat test test-suites/__setup.spec.ts test-suites/pool-l2.spec.ts",
     "test-subgraph:scenarios": ". ./setup-test-env.sh  && hardhat --network hardhatevm_docker test test-suites/__setup.spec.ts test-suites/subgraph-scenarios.spec.ts",

--- a/test-suites/helpers/contracts-helpers.ts
+++ b/test-suites/helpers/contracts-helpers.ts
@@ -1,0 +1,506 @@
+import { Contract, Signer, utils, ethers, BigNumberish } from 'ethers';
+import { signTypedData_v4 } from 'eth-sig-util';
+import { fromRpcSig, ECDSASignature } from 'ethereumjs-util';
+import BigNumber from 'bignumber.js';
+import { getDb, DRE, waitForTx, notFalsyOrZeroAddress } from './misc-utils';
+import {
+  tEthereumAddress,
+  eContractid,
+  tStringTokenSmallUnits,
+  eEthereumNetwork,
+  AavePools,
+  iParamsPerNetwork,
+  iParamsPerPool,
+  ePolygonNetwork,
+  eXDaiNetwork,
+  eNetwork,
+  iEthereumParamsPerNetwork,
+  iPolygonParamsPerNetwork,
+  iXDaiParamsPerNetwork,
+  iAvalancheParamsPerNetwork,
+  eAvalancheNetwork,
+} from './types';
+import { MintableERC20 } from '../types/MintableERC20';
+import { Artifact } from 'hardhat/types';
+import { Artifact as BuidlerArtifact } from '@nomiclabs/buidler/types';
+import { verifyEtherscanContract } from './etherscan-verification';
+import { getFirstSigner, getIErc20Detailed } from './contracts-getters';
+import { usingTenderly, verifyAtTenderly } from './tenderly-utils';
+import { usingPolygon, verifyAtPolygon } from './polygon-utils';
+import { ConfigNames, loadPoolConfig } from './configuration';
+import { ZERO_ADDRESS } from './constants';
+import { getDefenderRelaySigner, usingDefender } from './defender-utils';
+
+export type MockTokenMap = { [symbol: string]: MintableERC20 };
+
+const getBlockNumberByTxHash = async (txHash: string) => {
+  const receipt = await DRE.ethers.provider.getTransactionReceipt(txHash);
+  return receipt.blockNumber;
+};
+
+export const registerContractInJsonDb = async (contractId: string, contractInstance: Contract) => {
+  const currentNetwork = DRE.network.name;
+  const blockNumber = await getBlockNumberByTxHash(contractInstance.deployTransaction.hash);
+  const FORK = process.env.FORK;
+  if (FORK || (currentNetwork !== 'hardhat' && !currentNetwork.includes('coverage'))) {
+    console.log(`*** ${contractId} ***\n`);
+    console.log(`Network: ${currentNetwork}`);
+    console.log(`tx: ${contractInstance.deployTransaction.hash}`);
+    console.log(`contract address: ${contractInstance.address}`);
+    console.log(`deployer address: ${contractInstance.deployTransaction.from}`);
+    console.log(`gas price: ${contractInstance.deployTransaction.gasPrice}`);
+    console.log(`gas used: ${contractInstance.deployTransaction.gasLimit}`);
+    console.log(`blockNumber: ${blockNumber}`);
+    console.log(`\n******`);
+    console.log();
+  }
+
+  await getDb()
+    .set(`${contractId}.${currentNetwork}`, {
+      address: contractInstance.address,
+      deployer: contractInstance.deployTransaction.from,
+      blockNumber: blockNumber,
+    })
+    .write();
+};
+
+export const insertContractAddressInDb = async (id: eContractid, address: tEthereumAddress) =>
+  await getDb()
+    .set(`${id}.${DRE.network.name}`, {
+      address,
+    })
+    .write();
+
+export const rawInsertContractAddressInDb = async (id: string, address: tEthereumAddress) =>
+  await getDb()
+    .set(`${id}.${DRE.network.name}`, {
+      address,
+    })
+    .write();
+
+export const getEthersSigners = async (): Promise<Signer[]> => {
+  const ethersSigners = await Promise.all(await DRE.ethers.getSigners());
+
+  if (usingDefender()) {
+    const [, ...users] = ethersSigners;
+    return [await getDefenderRelaySigner(), ...users];
+  }
+  return ethersSigners;
+};
+
+export const getEthersSignersAddresses = async (): Promise<tEthereumAddress[]> =>
+  await Promise.all((await getEthersSigners()).map((signer) => signer.getAddress()));
+
+export const getCurrentBlock = async () => {
+  return DRE.ethers.provider.getBlockNumber();
+};
+
+export const decodeAbiNumber = (data: string): number =>
+  parseInt(utils.defaultAbiCoder.decode(['uint256'], data).toString());
+
+export const deployContract = async <ContractType extends Contract>(
+  contractName: string,
+  args: any[]
+): Promise<ContractType> => {
+  const contract = (await (await DRE.ethers.getContractFactory(contractName))
+    .connect(await getFirstSigner())
+    .deploy(...args)) as ContractType;
+  await waitForTx(contract.deployTransaction);
+  await registerContractInJsonDb(<eContractid>contractName, contract);
+  return contract;
+};
+
+export const withSaveAndVerify = async <ContractType extends Contract>(
+  instance: ContractType,
+  id: string,
+  args: (string | string[])[],
+  verify?: boolean
+): Promise<ContractType> => {
+  await waitForTx(instance.deployTransaction);
+  await registerContractInJsonDb(id, instance);
+  if (verify) {
+    await verifyContract(id, instance, args);
+  }
+  return instance;
+};
+
+export const getContract = async <ContractType extends Contract>(
+  contractName: string,
+  address: string
+): Promise<ContractType> => (await DRE.ethers.getContractAt(contractName, address)) as ContractType;
+
+export const linkBytecode = (artifact: BuidlerArtifact | Artifact, libraries: any) => {
+  let bytecode = artifact.bytecode;
+
+  for (const [fileName, fileReferences] of Object.entries(artifact.linkReferences)) {
+    for (const [libName, fixups] of Object.entries(fileReferences)) {
+      const addr = libraries[libName];
+
+      if (addr === undefined) {
+        continue;
+      }
+
+      for (const fixup of fixups) {
+        bytecode =
+          bytecode.substr(0, 2 + fixup.start * 2) +
+          addr.substr(2) +
+          bytecode.substr(2 + (fixup.start + fixup.length) * 2);
+      }
+    }
+  }
+
+  return bytecode;
+};
+
+export const getParamPerNetwork = <T>(param: iParamsPerNetwork<T>, network: eNetwork) => {
+  const {
+    main,
+    ropsten,
+    kovan,
+    coverage,
+    buidlerevm,
+    tenderly,
+    goerli,
+    sepolia,
+    baseSepolia,
+    bscTestnet,
+  } = param as iEthereumParamsPerNetwork<T>;
+  const { matic, mumbai } = param as iPolygonParamsPerNetwork<T>;
+  const { xdai } = param as iXDaiParamsPerNetwork<T>;
+  const { avalanche, fuji } = param as iAvalancheParamsPerNetwork<T>;
+  if (process.env.FORK) {
+    return param[process.env.FORK as eNetwork] as T;
+  }
+
+  switch (network) {
+    case eEthereumNetwork.coverage:
+      return coverage;
+    case eEthereumNetwork.buidlerevm:
+      return buidlerevm;
+    case eEthereumNetwork.hardhat:
+      return buidlerevm;
+    case eEthereumNetwork.kovan:
+      return kovan;
+    case eEthereumNetwork.ropsten:
+      return ropsten;
+    case eEthereumNetwork.main:
+      return main;
+    case eEthereumNetwork.tenderly:
+      return tenderly;
+    case ePolygonNetwork.matic:
+      return matic;
+    case ePolygonNetwork.mumbai:
+      return mumbai;
+    case eXDaiNetwork.xdai:
+      return xdai;
+    case eAvalancheNetwork.avalanche:
+      return avalanche;
+    case eAvalancheNetwork.fuji:
+      return fuji;
+    case eEthereumNetwork.goerli:
+      return goerli;
+    case eEthereumNetwork.sepolia:
+      return sepolia;
+    case eEthereumNetwork.baseSepolia:
+      return baseSepolia;
+    case eEthereumNetwork.bscTestnet:
+      return bscTestnet;
+  }
+};
+
+export const getOptionalParamAddressPerNetwork = (
+  param: iParamsPerNetwork<tEthereumAddress> | undefined | null,
+  network: eNetwork
+) => {
+  if (!param) {
+    return ZERO_ADDRESS;
+  }
+  return getParamPerNetwork(param, network);
+};
+
+export const getParamPerPool = <T>(
+  { proto, amm, matic, avalanche }: iParamsPerPool<T>,
+  pool: AavePools
+) => {
+  switch (pool) {
+    case AavePools.proto:
+      return proto;
+    case AavePools.amm:
+      return amm;
+    case AavePools.matic:
+      return matic;
+    case AavePools.avalanche:
+      return avalanche;
+    default:
+      return proto;
+  }
+};
+
+export const convertToCurrencyDecimals = async (tokenAddress: tEthereumAddress, amount: string) => {
+  const token = await getIErc20Detailed(tokenAddress);
+  let decimals = (await token.decimals()).toString();
+
+  return ethers.utils.parseUnits(amount, decimals);
+};
+
+export const convertToCurrencyUnits = async (tokenAddress: string, amount: string) => {
+  const token = await getIErc20Detailed(tokenAddress);
+  let decimals = new BigNumber(await token.decimals());
+  const currencyUnit = new BigNumber(10).pow(decimals);
+  const amountInCurrencyUnits = new BigNumber(amount).div(currencyUnit);
+  return amountInCurrencyUnits.toFixed();
+};
+
+export const buildPermitParams = (
+  chainId: number,
+  token: tEthereumAddress,
+  revision: string,
+  tokenName: string,
+  owner: tEthereumAddress,
+  spender: tEthereumAddress,
+  nonce: number,
+  deadline: string,
+  value: tStringTokenSmallUnits
+) => ({
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+    ],
+    Permit: [
+      { name: 'owner', type: 'address' },
+      { name: 'spender', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'nonce', type: 'uint256' },
+      { name: 'deadline', type: 'uint256' },
+    ],
+  },
+  primaryType: 'Permit' as const,
+  domain: {
+    name: tokenName,
+    version: revision,
+    chainId: chainId,
+    verifyingContract: token,
+  },
+  message: {
+    owner,
+    spender,
+    value,
+    nonce,
+    deadline,
+  },
+});
+
+export const getSignatureFromTypedData = (
+  privateKey: string,
+  typedData: any // TODO: should be TypedData, from eth-sig-utils, but TS doesn't accept it
+): ECDSASignature => {
+  const signature = signTypedData_v4(Buffer.from(privateKey.substring(2, 66), 'hex'), {
+    data: typedData,
+  });
+  return fromRpcSig(signature);
+};
+
+export const buildLiquiditySwapParams = (
+  assetToSwapToList: tEthereumAddress[],
+  minAmountsToReceive: BigNumberish[],
+  swapAllBalances: BigNumberish[],
+  permitAmounts: BigNumberish[],
+  deadlines: BigNumberish[],
+  v: BigNumberish[],
+  r: (string | Buffer)[],
+  s: (string | Buffer)[],
+  useEthPath: boolean[]
+) => {
+  return ethers.utils.defaultAbiCoder.encode(
+    [
+      'address[]',
+      'uint256[]',
+      'bool[]',
+      'uint256[]',
+      'uint256[]',
+      'uint8[]',
+      'bytes32[]',
+      'bytes32[]',
+      'bool[]',
+    ],
+    [
+      assetToSwapToList,
+      minAmountsToReceive,
+      swapAllBalances,
+      permitAmounts,
+      deadlines,
+      v,
+      r,
+      s,
+      useEthPath,
+    ]
+  );
+};
+
+export const buildRepayAdapterParams = (
+  collateralAsset: tEthereumAddress,
+  collateralAmount: BigNumberish,
+  rateMode: BigNumberish,
+  permitAmount: BigNumberish,
+  deadline: BigNumberish,
+  v: BigNumberish,
+  r: string | Buffer,
+  s: string | Buffer,
+  useEthPath: boolean
+) => {
+  return ethers.utils.defaultAbiCoder.encode(
+    ['address', 'uint256', 'uint256', 'uint256', 'uint256', 'uint8', 'bytes32', 'bytes32', 'bool'],
+    [collateralAsset, collateralAmount, rateMode, permitAmount, deadline, v, r, s, useEthPath]
+  );
+};
+
+export const buildFlashLiquidationAdapterParams = (
+  collateralAsset: tEthereumAddress,
+  debtAsset: tEthereumAddress,
+  user: tEthereumAddress,
+  debtToCover: BigNumberish,
+  useEthPath: boolean
+) => {
+  return ethers.utils.defaultAbiCoder.encode(
+    ['address', 'address', 'address', 'uint256', 'bool'],
+    [collateralAsset, debtAsset, user, debtToCover, useEthPath]
+  );
+};
+
+export const buildParaSwapLiquiditySwapParams = (
+  assetToSwapTo: tEthereumAddress,
+  minAmountToReceive: BigNumberish,
+  swapAllBalanceOffset: BigNumberish,
+  swapCalldata: string | Buffer,
+  augustus: tEthereumAddress,
+  permitAmount: BigNumberish,
+  deadline: BigNumberish,
+  v: BigNumberish,
+  r: string | Buffer,
+  s: string | Buffer
+) => {
+  return ethers.utils.defaultAbiCoder.encode(
+    [
+      'address',
+      'uint256',
+      'uint256',
+      'bytes',
+      'address',
+      'tuple(uint256,uint256,uint8,bytes32,bytes32)',
+    ],
+    [
+      assetToSwapTo,
+      minAmountToReceive,
+      swapAllBalanceOffset,
+      swapCalldata,
+      augustus,
+      [permitAmount, deadline, v, r, s],
+    ]
+  );
+};
+
+export const buildKyberSwapLiquiditySwapParams = (
+  assetToSwapTo: tEthereumAddress,
+  minAmountToReceive: BigNumberish,
+  swapAllBalanceOffset: BigNumberish,
+  swapCalldata: string | Buffer,
+  kyberProxy: tEthereumAddress,
+  permitAmount: BigNumberish,
+  deadline: BigNumberish,
+  v: BigNumberish,
+  r: string | Buffer,
+  s: string | Buffer
+) => {
+  return ethers.utils.defaultAbiCoder.encode(
+    [
+      'address',
+      'uint256',
+      'uint256',
+      'bytes',
+      'address',
+      'tuple(uint256,uint256,uint8,bytes32,bytes32)',
+    ],
+    [
+      assetToSwapTo,
+      minAmountToReceive,
+      swapAllBalanceOffset,
+      swapCalldata,
+      kyberProxy,
+      [permitAmount, deadline, v, r, s],
+    ]
+  );
+};
+
+export const verifyContract = async (
+  id: string,
+  instance: Contract,
+  args: (string | string[])[],
+  contractFQN?: string // Optional parameter
+) => {
+  if (usingTenderly()) {
+    await verifyAtTenderly(id, instance);
+  }
+  await verifyEtherscanContract(instance.address, args, undefined, contractFQN);
+  return instance;
+};
+
+export const getContractAddressWithJsonFallback = async (
+  id: string,
+  pool: ConfigNames
+): Promise<tEthereumAddress> => {
+  const poolConfig = loadPoolConfig(pool);
+  const network = <eNetwork>DRE.network.name;
+  const db = getDb();
+
+  const contractAtMarketConfig = getOptionalParamAddressPerNetwork(poolConfig[id], network);
+  if (notFalsyOrZeroAddress(contractAtMarketConfig)) {
+    return contractAtMarketConfig;
+  }
+
+  const contractAtDb = await getDb().get(`${id}.${DRE.network.name}`).value();
+  if (contractAtDb?.address) {
+    return contractAtDb.address as tEthereumAddress;
+  }
+  throw Error(`Missing contract address ${id} at Market config and JSON local db`);
+};
+
+export const printContracts = () => {
+  const network = DRE.network.name;
+  const db = getDb();
+  console.log('Contracts deployed at', network);
+  console.log('---------------------------------');
+
+  const entries = Object.entries(db.getState()).filter(
+    ([_k, value]: [string, any]) => !!value[network]
+  );
+
+  const contractsPrint = entries.map(([key, value]: [string, any]) => {
+    const blockNumber = value[network].blockNumber || 'N/A';
+    return `${key}: ${value[network].address} (Block: ${blockNumber})`;
+  });
+
+  console.log('N# Contracts:', entries.length);
+  console.log(contractsPrint.join('\n'), '\n');
+};
+
+export const printReserveAssets = (pool: ConfigNames) => {
+  const network = DRE.network.name;
+  const db = getDb();
+  const poolConfig = loadPoolConfig(pool);
+  const reserveAssets = poolConfig.ReserveAssets[network];
+
+  const entries = Object.entries(db.getState()).filter(([_k, value]: [string, any]) => {
+    return !!value[network] && Object.keys(reserveAssets).some((asset) => _k.includes(asset));
+  });
+
+  const contractsPrint = entries.map(
+    ([key, value]: [string, DbEntry]) =>
+      `${key}: ${value[network].address} (Block: ${value[network].blockNumber})`
+  );
+
+  console.log('N# Contracts:', entries.length);
+  console.log(contractsPrint.join('\n'), '\n');
+};

--- a/test-suites/paraswapAdapters.liquiditySwap.spec.ts
+++ b/test-suites/paraswapAdapters.liquiditySwap.spec.ts
@@ -1,0 +1,2887 @@
+import { makeSuite, TestEnv } from './helpers/make-suite';
+import {
+  convertToCurrencyDecimals,
+  buildPermitParams,
+  getSignatureFromTypedData,
+  buildParaSwapLiquiditySwapParams,
+} from '../helpers/contracts-helpers';
+import { Zero } from '@ethersproject/constants';
+import BigNumber from 'bignumber.js';
+import { ethers } from 'ethers';
+import { MAX_UINT_AMOUNT } from '../helpers/constants';
+import { evmRevert, evmSnapshot, getAToken, getFirstSigner } from '@aave/deploy-v3';
+import { tEthereumAddress } from '../helpers/types';
+const { parseEther } = ethers.utils;
+import {
+  ParaSwapLiquiditySwapAdapter,
+  ParaSwapLiquiditySwapAdapter__factory,
+  MockParaSwapAugustus,
+  MockParaSwapAugustusRegistry,
+  MockParaSwapAugustus__factory,
+  MockParaSwapAugustusRegistry__factory,
+} from '../types';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+declare var hre: HardhatRuntimeEnvironment;
+
+const { expect } = require('chai');
+
+export const deployParaSwapLiquiditySwapAdapter = async (
+  addressesProvider: tEthereumAddress,
+  augustusRegistry: tEthereumAddress
+) =>
+  await new ParaSwapLiquiditySwapAdapter__factory(await getFirstSigner()).deploy(
+    addressesProvider,
+    augustusRegistry
+  );
+
+makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
+  let mockAugustus: MockParaSwapAugustus;
+  let mockAugustusRegistry: MockParaSwapAugustusRegistry;
+  let paraswapLiquiditySwapAdapter: ParaSwapLiquiditySwapAdapter;
+  let evmSnapshotId: string;
+
+  before(async () => {
+    const signer = await getFirstSigner();
+    mockAugustus = await new MockParaSwapAugustus__factory(signer).deploy();
+    mockAugustusRegistry = await new MockParaSwapAugustusRegistry__factory(signer).deploy(
+      mockAugustus.address
+    );
+    console.log('Deployed mockAugustus and mockAugustusRegistry...');
+    console.log('mockAugustus', mockAugustus.address);
+    console.log('mockAugustusRegistry', mockAugustusRegistry.address);
+    paraswapLiquiditySwapAdapter = await deployParaSwapLiquiditySwapAdapter(
+      testEnv.addressesProvider.address,
+      mockAugustusRegistry.address
+    );
+    console.log('Deployed paraswapLiquiditySwapAdapter...');
+    console.log('paraswapLiquiditySwapAdapter', paraswapLiquiditySwapAdapter.address);
+  });
+
+  beforeEach(async () => {
+    evmSnapshotId = await evmSnapshot();
+  });
+
+  afterEach(async () => {
+    await evmRevert(evmSnapshotId);
+  });
+
+  describe('ParaSwapLiquiditySwapAdapter', () => {
+    describe('executeOperation', () => {
+      beforeEach(async () => {
+        const {
+          users: [user],
+          weth,
+          aave,
+          pool,
+          deployer,
+        } = testEnv;
+        const userAddress = user.address;
+
+        // Provide liquidity
+        const aaveAmount = await convertToCurrencyDecimals(aave.address, '20000');
+        await aave
+          .connect(deployer.signer)
+          .functions['mint(address,uint256)'](deployer.address, aaveAmount);
+        await aave.connect(deployer.signer).approve(pool.address, aaveAmount);
+        await pool.connect(deployer.signer).deposit(aave.address, aaveAmount, deployer.address, 0);
+
+        const wethAmount = await convertToCurrencyDecimals(weth.address, '10000');
+        await weth
+          .connect(deployer.signer)
+          .functions['mint(address,uint256)'](deployer.address, wethAmount);
+        await weth.connect(deployer.signer).approve(pool.address, wethAmount);
+        await pool.connect(deployer.signer).deposit(weth.address, wethAmount, deployer.address, 0);
+
+        // Make a deposit for user
+        const userWethAmount = await convertToCurrencyDecimals(weth.address, '100');
+        await weth
+          .connect(user.signer)
+          .functions['mint(address,uint256)'](userAddress, userWethAmount);
+        await weth.connect(user.signer).approve(pool.address, userWethAmount);
+        await pool.connect(user.signer).deposit(weth.address, userWethAmount, userAddress, 0);
+      });
+
+      it('should correctly swap tokens and deposit the out tokens in the pool', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aAave,
+          aWETH,
+        } = testEnv;
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        console.log('aavePrice:', aavePrice.toString());
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus
+          .connect(user.signer)
+          .expectSwap(
+            weth.address,
+            aave.address,
+            amountWETHtoSwap,
+            amountWETHtoSwap,
+            expectedUsdcAmount
+          );
+
+        const flashloanPremium = amountWETHtoSwap.mul(9).div(10000);
+        const flashloanTotal = amountWETHtoSwap.add(flashloanPremium);
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, flashloanTotal);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        const params = buildParaSwapLiquiditySwapParams(
+          aave.address,
+          expectedUsdcAmount,
+          0,
+          mockAugustusCalldata,
+          mockAugustus.address,
+          0,
+          0,
+          0,
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+          '0x0000000000000000000000000000000000000000000000000000000000000000'
+        );
+
+        console.log('From test:');
+        console.log('userAddress:', userAddress);
+        console.log('paraswapLiquiditySwapAdapter.address:', paraswapLiquiditySwapAdapter.address);
+        console.log('weth.address:', weth.address);
+        console.log('amountWETHtoSwap:', amountWETHtoSwap);
+        console.log('expectedUsdcAmount:', expectedUsdcAmount);
+        console.log('params:', params);
+
+        await expect(
+          pool
+            .connect(user.signer)
+            .flashLoan(
+              paraswapLiquiditySwapAdapter.address,
+              [weth.address],
+              [amountWETHtoSwap],
+              [0],
+              userAddress,
+              params,
+              0
+            )
+        )
+          .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+          .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        // N.B. will get some portion of flashloan premium back from the pool
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.gte(userAEthBalanceBefore.sub(flashloanTotal));
+        expect(userAEthBalance).to.be.lte(userAEthBalanceBefore.sub(amountWETHtoSwap));
+      });
+
+      it('should correctly swap tokens using permit', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aAave,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        const flashloanPremium = amountWETHtoSwap.mul(9).div(10000);
+        const flashloanTotal = amountWETHtoSwap.add(flashloanPremium);
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+
+        const chainId = hre.network.config.chainId || 31337;
+        const deadline = MAX_UINT_AMOUNT;
+        const nonce = (await aWETH._nonces(userAddress)).toNumber();
+        const msgParams = buildPermitParams(
+          chainId,
+          aWETH.address,
+          '1',
+          await aWETH.name(),
+          userAddress,
+          paraswapLiquiditySwapAdapter.address,
+          nonce,
+          deadline,
+          flashloanTotal.toString()
+        );
+
+        const ownerPrivateKey = require('../../test-wallets.js').accounts[1].secretKey;
+        if (!ownerPrivateKey) {
+          throw new Error('INVALID_OWNER_PK');
+        }
+
+        const { v, r, s } = getSignatureFromTypedData(ownerPrivateKey, msgParams);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        const params = buildParaSwapLiquiditySwapParams(
+          aave.address,
+          expectedUsdcAmount,
+          0,
+          mockAugustusCalldata,
+          mockAugustus.address,
+          flashloanTotal,
+          deadline,
+          v,
+          r,
+          s
+        );
+
+        await expect(
+          pool
+            .connect(user.signer)
+            .flashLoan(
+              paraswapLiquiditySwapAdapter.address,
+              [weth.address],
+              [amountWETHtoSwap],
+              [0],
+              userAddress,
+              params,
+              0
+            )
+        )
+          .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+          .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        // N.B. will get some portion of flashloan premium back from the pool
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.gte(userAEthBalanceBefore.sub(flashloanTotal));
+        expect(userAEthBalance).to.be.lte(userAEthBalanceBefore.sub(amountWETHtoSwap));
+      });
+
+      it('should revert if caller not lending pool', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aAave,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        const flashloanPremium = amountWETHtoSwap.mul(9).div(10000);
+        const flashloanTotal = amountWETHtoSwap.add(flashloanPremium);
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, flashloanTotal);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        const params = buildParaSwapLiquiditySwapParams(
+          aave.address,
+          expectedUsdcAmount,
+          0,
+          mockAugustusCalldata,
+          mockAugustus.address,
+          0,
+          0,
+          0,
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+          '0x0000000000000000000000000000000000000000000000000000000000000000'
+        );
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .executeOperation([weth.address], [amountWETHtoSwap], [0], userAddress, params)
+        ).to.be.revertedWith('CALLER_MUST_BE_LENDING_POOL');
+      });
+
+      it('should work correctly with tokens of different decimals', async () => {
+        const {
+          users: [user],
+          aave,
+          oracle,
+          weth,
+          pool,
+          deployer,
+          aAave,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountUSDCtoSwap = await convertToCurrencyDecimals(aave.address, '10');
+        const liquidity = await convertToCurrencyDecimals(aave.address, '20000');
+
+        const flashloanPremium = amountUSDCtoSwap.mul(9).div(10000);
+        const flashloanTotal = amountUSDCtoSwap.add(flashloanPremium);
+
+        // Provider liquidity
+        await aave.functions['mint(address,uint256)'](deployer.address, liquidity);
+        await aave.approve(pool.address, liquidity);
+        await pool.deposit(aave.address, liquidity, deployer.address, 0);
+
+        // Make a deposit for user
+        await aave
+          .connect(user.signer)
+          .functions['mint(address,uint256)'](userAddress, flashloanTotal);
+        await aave.connect(user.signer).approve(pool.address, flashloanTotal);
+        await pool.connect(user.signer).deposit(aave.address, flashloanTotal, userAddress, 0);
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+
+        const collateralDecimals = (await aave.decimals()).toString();
+        const principalDecimals = (await aave.decimals()).toString();
+
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountUSDCtoSwap.toString())
+            .times(
+              new BigNumber(aavePrice.toString()).times(new BigNumber(10).pow(principalDecimals))
+            )
+            .div(
+              new BigNumber(aavePrice.toString()).times(new BigNumber(10).pow(collateralDecimals))
+            )
+            .div(new BigNumber(10).pow(principalDecimals))
+            .toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          aave.address,
+          aave.address,
+          amountUSDCtoSwap,
+          amountUSDCtoSwap,
+          expectedUsdcAmount
+        );
+
+        const zUSDC = await getAToken(aave.address);
+
+        // User will swap liquidity zUSDC to zUsdc
+        const userzUSDCBalanceBefore = await zUSDC.balanceOf(userAddress);
+        await zUSDC
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, flashloanTotal);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          aave.address,
+          aave.address,
+          amountUSDCtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        const params = buildParaSwapLiquiditySwapParams(
+          aave.address,
+          expectedUsdcAmount,
+          0,
+          mockAugustusCalldata,
+          mockAugustus.address,
+          0,
+          0,
+          0,
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+          '0x0000000000000000000000000000000000000000000000000000000000000000'
+        );
+
+        await expect(
+          pool
+            .connect(user.signer)
+            .flashLoan(
+              paraswapLiquiditySwapAdapter.address,
+              [aave.address],
+              [amountUSDCtoSwap],
+              [0],
+              userAddress,
+              params,
+              0
+            )
+        )
+          .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+          .withArgs(aave.address, aave.address, amountUSDCtoSwap, expectedUsdcAmount);
+
+        const adapterUsdcBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userzUSDCBalance = await zUSDC.balanceOf(userAddress);
+
+        // N.B. will get some portion of flashloan premium back from the pool
+        expect(adapterUsdcBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userzUSDCBalance).to.be.gte(userzUSDCBalanceBefore.sub(flashloanTotal));
+        expect(userzUSDCBalance).to.be.lte(userzUSDCBalanceBefore.sub(amountUSDCtoSwap));
+      });
+
+      it('should revert when min amount to receive exceeds the max slippage amount', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        const smallexpectedUsdcAmount = expectedUsdcAmount.div(2);
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              smallexpectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('MIN_AMOUNT_EXCEEDS_MAX_SLIPPAGE');
+      });
+
+      it('should revert if wrong address used for Augustus', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter.connect(user.signer).swapAndDeposit(
+            weth.address,
+            aave.address,
+            amountWETHtoSwap,
+            expectedUsdcAmount,
+            0,
+            mockAugustusCalldata,
+            oracle.address, // using arbitrary contract instead of mock Augustus
+            {
+              amount: 0,
+              deadline: 0,
+              v: 0,
+              r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            }
+          )
+        ).to.be.revertedWith('INVALID_AUGUSTUS');
+      });
+
+      it('should bubble up errors from Augustus', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        // Add 1 to expected amount so it will fail
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount.add(1),
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('Received amount of tokens are less than expected');
+      });
+
+      it('should revert if Augustus swaps for less than minimum to receive', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+        const actualZbuAmount = expectedUsdcAmount.sub(1);
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          actualZbuAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          actualZbuAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('INSUFFICIENT_AMOUNT_RECEIVED');
+      });
+
+      it("should revert if Augustus doesn't swap correct amount", async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        const augustusSwapAmount = amountWETHtoSwap.sub(1);
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          augustusSwapAmount,
+          augustusSwapAmount,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          augustusSwapAmount,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('WRONG_BALANCE_AFTER_SWAP');
+      });
+
+      it('should correctly swap all the balance when using a bigger amount', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aAave,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // Remove other balance
+        const transferAmount = await convertToCurrencyDecimals(aWETH.address, '90');
+        await aWETH.connect(user.signer).transfer(users[1].address, transferAmount);
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+        expect(userAEthBalanceBefore).to.be.eq(amountWETHtoSwap);
+
+        const bigAmountToSwap = await convertToCurrencyDecimals(aWETH.address, '11');
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, bigAmountToSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          bigAmountToSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              bigAmountToSwap,
+              expectedUsdcAmount,
+              4 + 2 * 32,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        )
+          .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+          .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.eq(Zero);
+      });
+
+      it('should correctly swap all the balance when using permit', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aAave,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // Remove other balance
+        const transferAmount = await convertToCurrencyDecimals(aWETH.address, '90');
+        await aWETH.connect(user.signer).transfer(users[1].address, transferAmount);
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+        expect(userAEthBalanceBefore).to.be.eq(amountWETHtoSwap);
+
+        const bigAmountToSwap = await convertToCurrencyDecimals(aWETH.address, '11');
+
+        const chainId = hre.network.config.chainId || 31337;
+        const deadline = MAX_UINT_AMOUNT;
+        const nonce = (await aWETH._nonces(userAddress)).toNumber();
+        const msgParams = buildPermitParams(
+          chainId,
+          aWETH.address,
+          '1',
+          await aWETH.name(),
+          userAddress,
+          paraswapLiquiditySwapAdapter.address,
+          nonce,
+          deadline,
+          bigAmountToSwap.toString()
+        );
+
+        const ownerPrivateKey = require('../../test-wallets.js').accounts[1].secretKey;
+        if (!ownerPrivateKey) {
+          throw new Error('INVALID_OWNER_PK');
+        }
+
+        const { v, r, s } = getSignatureFromTypedData(ownerPrivateKey, msgParams);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          bigAmountToSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              bigAmountToSwap,
+              expectedUsdcAmount,
+              4 + 2 * 32,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: bigAmountToSwap,
+                deadline,
+                v,
+                r,
+                s,
+              }
+            )
+        ).to.emit(paraswapLiquiditySwapAdapter, 'Swapped');
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.eq(Zero);
+      });
+
+      it('should revert trying to swap all the balance when using a smaller amount', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // Remove other balance
+        const transferAmount = await convertToCurrencyDecimals(aWETH.address, '90');
+        await aWETH.connect(user.signer).transfer(users[1].address, transferAmount);
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+        expect(userAEthBalanceBefore).to.be.eq(amountWETHtoSwap);
+
+        const smallAmountToSwap = (await convertToCurrencyDecimals(aWETH.address, '10')).sub(1);
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, smallAmountToSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          smallAmountToSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              smallAmountToSwap,
+              expectedUsdcAmount,
+              4 + 2 * 32,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('INSUFFICIENT_AMOUNT_TO_SWAP');
+      });
+
+      it('should not touch any token balance already in the adapter', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aAave,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        // Put token balances in the adapter
+        const adapterWethBalanceBefore = await convertToCurrencyDecimals(weth.address, '123');
+        await weth.functions['mint(address,uint256)'](
+          paraswapLiquiditySwapAdapter.address,
+          adapterWethBalanceBefore
+        );
+        await weth.transfer(paraswapLiquiditySwapAdapter.address, adapterWethBalanceBefore);
+        const adapterZbuBalanceBefore = await convertToCurrencyDecimals(aave.address, '234');
+        await aave.functions['mint(address,uint256)'](
+          paraswapLiquiditySwapAdapter.address,
+          adapterZbuBalanceBefore
+        );
+        await aave.transfer(paraswapLiquiditySwapAdapter.address, adapterZbuBalanceBefore);
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        )
+          .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+          .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(adapterWethBalanceBefore);
+        expect(adapterZbuBalance).to.be.eq(adapterZbuBalanceBefore);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.eq(userAEthBalanceBefore.sub(amountWETHtoSwap));
+      });
+    });
+
+    describe('executeOperation with borrowing', () => {
+      beforeEach(async () => {
+        const {
+          users: [user],
+          weth,
+          aave,
+          pool,
+          deployer,
+        } = testEnv;
+        const userAddress = user.address;
+        const borrower = users[1].signer;
+        const borrowerAddress = users[1].address;
+
+        // Provide liquidity
+        const usdcAmount = await convertToCurrencyDecimals(aave.address, '20000');
+        await aave.functions['mint(address,uint256)'](deployer.address, usdcAmount);
+        await aave.approve(pool.address, usdcAmount);
+        await pool.deposit(aave.address, usdcAmount, deployer.address, 0);
+
+        const wethAmount = await convertToCurrencyDecimals(weth.address, '10000');
+        await weth.functions['mint(address,uint256)'](deployer.address, wethAmount);
+        await weth.approve(pool.address, wethAmount);
+        await pool.deposit(weth.address, wethAmount, deployer.address, 0);
+
+        // Make a deposit for user
+        const userWethAmount = await convertToCurrencyDecimals(weth.address, '100');
+        await weth.functions['mint(address,uint256)'](userAddress, userWethAmount);
+        await weth.approve(pool.address, userWethAmount);
+        await pool.deposit(weth.address, userWethAmount, userAddress, 0);
+
+        // Add borrowing
+        const collateralAmount = parseEther('10000000');
+        await aave.functions['mint(address,uint256)'](borrowerAddress, collateralAmount);
+        await aave.approve(pool.address, collateralAmount);
+        await pool.deposit(aave.address, collateralAmount, borrowerAddress, 0);
+        await pool
+          .connect(borrower)
+          .borrow(weth.address, parseEther('5000'), 2, 0, borrowerAddress);
+      });
+
+      it('should correctly swap tokens and deposit the out tokens in the pool', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+          aAave,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        const flashloanPremium = amountWETHtoSwap.mul(9).div(10000);
+        const flashloanTotal = amountWETHtoSwap.add(flashloanPremium);
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, flashloanTotal);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        const params = buildParaSwapLiquiditySwapParams(
+          aave.address,
+          expectedUsdcAmount,
+          0,
+          mockAugustusCalldata,
+          mockAugustus.address,
+          0,
+          0,
+          0,
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+          '0x0000000000000000000000000000000000000000000000000000000000000000'
+        );
+
+        await expect(
+          pool
+            .connect(user.signer)
+            .flashLoan(
+              paraswapLiquiditySwapAdapter.address,
+              [weth.address],
+              [amountWETHtoSwap],
+              [0],
+              userAddress,
+              params,
+              0
+            )
+        )
+          .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+          .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.gt(userAEthBalanceBefore.sub(flashloanTotal));
+        expect(userAEthBalance).to.be.lt(
+          userAEthBalanceBefore.mul(10001).div(10000).sub(amountWETHtoSwap)
+        );
+      });
+
+      it('should correctly swap tokens using permit', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+          aAave,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        const flashloanPremium = amountWETHtoSwap.mul(9).div(10000);
+        const flashloanTotal = amountWETHtoSwap.add(flashloanPremium);
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+
+        const chainId = hre.network.config.chainId || 31337;
+        const deadline = MAX_UINT_AMOUNT;
+        const nonce = (await aWETH._nonces(userAddress)).toNumber();
+        const msgParams = buildPermitParams(
+          chainId,
+          aWETH.address,
+          '1',
+          await aWETH.name(),
+          userAddress,
+          paraswapLiquiditySwapAdapter.address,
+          nonce,
+          deadline,
+          amountWETHtoSwap.toString()
+        );
+
+        const ownerPrivateKey = require('../../test-wallets.js').accounts[1].secretKey;
+        if (!ownerPrivateKey) {
+          throw new Error('INVALID_OWNER_PK');
+        }
+
+        const { v, r, s } = getSignatureFromTypedData(ownerPrivateKey, msgParams);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: amountWETHtoSwap,
+                deadline,
+                v,
+                r,
+                s,
+              }
+            )
+        )
+          .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+          .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.gt(userAEthBalanceBefore.sub(amountWETHtoSwap));
+        expect(userAEthBalance).to.be.lt(
+          userAEthBalanceBefore.mul(10001).div(10000).sub(amountWETHtoSwap)
+        );
+      });
+
+      it('should correctly swap all the balance when using a bigger amount', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aAave,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap.add(1),
+          amountWETHtoSwap.mul(10001).div(10000),
+          expectedUsdcAmount
+        );
+
+        // Remove other balance
+        const transferAmount = await convertToCurrencyDecimals(aWETH.address, '90');
+        await aWETH.connect(user.signer).transfer(users[1].address, transferAmount);
+
+        // User will swap liquidity aEth to zUsdc
+        const bigAmountToSwap = await convertToCurrencyDecimals(aWETH.address, '11');
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, bigAmountToSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          bigAmountToSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              bigAmountToSwap,
+              expectedUsdcAmount,
+              4 + 2 * 32,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.emit(paraswapLiquiditySwapAdapter, 'Swapped');
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.eq(Zero);
+      });
+
+      it('should correctly swap all the balance when using permit', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aAave,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap.add(1),
+          amountWETHtoSwap.mul(10001).div(10000),
+          expectedUsdcAmount
+        );
+
+        // Remove other balance
+        const transferAmount = await convertToCurrencyDecimals(aWETH.address, '90');
+        await aWETH.connect(user.signer).transfer(users[1].address, transferAmount);
+
+        // User will swap liquidity aEth to zUsdc
+        const bigAmountToSwap = await convertToCurrencyDecimals(aWETH.address, '11');
+
+        const chainId = hre.network.config.chainId || 31337;
+        const deadline = MAX_UINT_AMOUNT;
+        const nonce = (await aWETH._nonces(userAddress)).toNumber();
+        const msgParams = buildPermitParams(
+          chainId,
+          aWETH.address,
+          '1',
+          await aWETH.name(),
+          userAddress,
+          paraswapLiquiditySwapAdapter.address,
+          nonce,
+          deadline,
+          bigAmountToSwap.toString()
+        );
+
+        const ownerPrivateKey = require('../../test-wallets.js').accounts[1].secretKey;
+        if (!ownerPrivateKey) {
+          throw new Error('INVALID_OWNER_PK');
+        }
+
+        const { v, r, s } = getSignatureFromTypedData(ownerPrivateKey, msgParams);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          bigAmountToSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              bigAmountToSwap,
+              expectedUsdcAmount,
+              4 + 2 * 32,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: bigAmountToSwap,
+                deadline,
+                v,
+                r,
+                s,
+              }
+            )
+        ).to.emit(paraswapLiquiditySwapAdapter, 'Swapped');
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.eq(Zero);
+      });
+    });
+
+    describe('swapAndDeposit', () => {
+      beforeEach(async () => {
+        const {
+          users: [user],
+          weth,
+          aave,
+          pool,
+          deployer,
+        } = testEnv;
+        const userAddress = user.address;
+
+        // Provide liquidity
+        const usdcAmount = await convertToCurrencyDecimals(aave.address, '20000');
+        await aave.functions['mint(address,uint256)'](deployer.address, usdcAmount);
+        await aave.approve(pool.address, usdcAmount);
+        await pool.deposit(aave.address, usdcAmount, deployer.address, 0);
+
+        const wethAmount = await convertToCurrencyDecimals(weth.address, '10000');
+        await weth.functions['mint(address,uint256)'](deployer.address, wethAmount);
+        await weth.approve(pool.address, wethAmount);
+        await pool.deposit(weth.address, wethAmount, deployer.address, 0);
+
+        // Make a deposit for user
+        const userWethAmount = await convertToCurrencyDecimals(weth.address, '100');
+        await weth.functions['mint(address,uint256)'](userAddress, userWethAmount);
+        await weth.approve(pool.address, userWethAmount);
+        await pool.deposit(weth.address, userWethAmount, userAddress, 0);
+      });
+
+      it('should correctly swap tokens and deposit the out tokens in the pool', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+          aAave,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        )
+          .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+          .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.eq(userAEthBalanceBefore.sub(amountWETHtoSwap));
+      });
+
+      it('should correctly swap tokens using permit', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+          aAave,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+
+        const chainId = hre.network.config.chainId || 31337;
+        const deadline = MAX_UINT_AMOUNT;
+        const nonce = (await aWETH._nonces(userAddress)).toNumber();
+        const msgParams = buildPermitParams(
+          chainId,
+          aWETH.address,
+          '1',
+          await aWETH.name(),
+          userAddress,
+          paraswapLiquiditySwapAdapter.address,
+          nonce,
+          deadline,
+          amountWETHtoSwap.toString()
+        );
+
+        const ownerPrivateKey = require('../../test-wallets.js').accounts[1].secretKey;
+        if (!ownerPrivateKey) {
+          throw new Error('INVALID_OWNER_PK');
+        }
+
+        const { v, r, s } = getSignatureFromTypedData(ownerPrivateKey, msgParams);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: amountWETHtoSwap,
+                deadline,
+                v,
+                r,
+                s,
+              }
+            )
+        )
+          .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+          .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.eq(userAEthBalanceBefore.sub(amountWETHtoSwap));
+      });
+
+      it('should revert when trying to swap more than balance', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = (await convertToCurrencyDecimals(weth.address, '100')).add(1);
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('SafeERC20: low-level call failed');
+      });
+
+      it('should revert when trying to swap more than allowance', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap.sub(1));
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('SafeERC20: low-level call failed');
+      });
+
+      it('should revert when min amount to receive exceeds the max slippage amount', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        const smallexpectedUsdcAmount = expectedUsdcAmount.div(2);
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              smallexpectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('MIN_AMOUNT_EXCEEDS_MAX_SLIPPAGE');
+      });
+
+      it('should revert if wrong address used for Augustus', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter.connect(user.signer).swapAndDeposit(
+            weth.address,
+            aave.address,
+            amountWETHtoSwap,
+            expectedUsdcAmount,
+            0,
+            mockAugustusCalldata,
+            oracle.address, // using arbitrary contract instead of mock Augustus
+            {
+              amount: 0,
+              deadline: 0,
+              v: 0,
+              r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            }
+          )
+        ).to.be.revertedWith('INVALID_AUGUSTUS');
+      });
+
+      it('should bubble up errors from Augustus', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        // Add 1 to expected amount so it will fail
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount.add(1),
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('Received amount of tokens are less than expected');
+      });
+
+      it('should revert if Augustus swaps for less than minimum to receive', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+        const actualZbuAmount = expectedUsdcAmount.sub(1);
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          actualZbuAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          actualZbuAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('INSUFFICIENT_AMOUNT_RECEIVED');
+      });
+
+      it("should revert if Augustus doesn't swap correct amount", async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        const augustusSwapAmount = amountWETHtoSwap.sub(1);
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          augustusSwapAmount,
+          augustusSwapAmount,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          augustusSwapAmount,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('WRONG_BALANCE_AFTER_SWAP');
+      });
+
+      it('should correctly swap all the balance when using a bigger amount', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aAave,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // Remove other balance
+        const transferAmount = await convertToCurrencyDecimals(aWETH.address, '90');
+        await aWETH.connect(user.signer).transfer(users[1].address, transferAmount);
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+        expect(userAEthBalanceBefore).to.be.eq(amountWETHtoSwap);
+
+        const bigAmountToSwap = await convertToCurrencyDecimals(aWETH.address, '11');
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, bigAmountToSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          bigAmountToSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              bigAmountToSwap,
+              expectedUsdcAmount,
+              4 + 2 * 32,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        )
+          .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+          .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.eq(Zero);
+      });
+
+      it('should correctly swap all the balance when using permit', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aAave,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // Remove other balance
+        const transferAmount = await convertToCurrencyDecimals(aWETH.address, '90');
+        await aWETH.connect(user.signer).transfer(users[1].address, transferAmount);
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+        expect(userAEthBalanceBefore).to.be.eq(amountWETHtoSwap);
+
+        const bigAmountToSwap = await convertToCurrencyDecimals(aWETH.address, '11');
+
+        const chainId = hre.network.config.chainId || 31337;
+        const deadline = MAX_UINT_AMOUNT;
+        const nonce = (await aWETH._nonces(userAddress)).toNumber();
+        const msgParams = buildPermitParams(
+          chainId,
+          aWETH.address,
+          '1',
+          await aWETH.name(),
+          userAddress,
+          paraswapLiquiditySwapAdapter.address,
+          nonce,
+          deadline,
+          bigAmountToSwap.toString()
+        );
+
+        const ownerPrivateKey = require('../../test-wallets.js').accounts[1].secretKey;
+        if (!ownerPrivateKey) {
+          throw new Error('INVALID_OWNER_PK');
+        }
+
+        const { v, r, s } = getSignatureFromTypedData(ownerPrivateKey, msgParams);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          bigAmountToSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              bigAmountToSwap,
+              expectedUsdcAmount,
+              4 + 2 * 32,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: bigAmountToSwap,
+                deadline,
+                v,
+                r,
+                s,
+              }
+            )
+        ).to.emit(paraswapLiquiditySwapAdapter, 'Swapped');
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(Zero);
+        expect(adapterZbuBalance).to.be.eq(Zero);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.eq(Zero);
+      });
+
+      it('should revert trying to swap all the balance when using a smaller amount', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // Remove other balance
+        const transferAmount = await convertToCurrencyDecimals(aWETH.address, '90');
+        await aWETH.connect(user.signer).transfer(users[1].address, transferAmount);
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+        expect(userAEthBalanceBefore).to.be.eq(amountWETHtoSwap);
+
+        const smallAmountToSwap = (await convertToCurrencyDecimals(aWETH.address, '10')).sub(1);
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, smallAmountToSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          smallAmountToSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              smallAmountToSwap,
+              expectedUsdcAmount,
+              4 + 2 * 32,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        ).to.be.revertedWith('INSUFFICIENT_AMOUNT_TO_SWAP');
+      });
+
+      it('should not touch any token balance already in the adapter', async () => {
+        const {
+          users: [user],
+          weth,
+          oracle,
+          aave,
+          pool,
+          aAave,
+          aWETH,
+        } = testEnv;
+
+        const userAddress = user.address;
+
+        // Put token balances in the adapter
+        const adapterWethBalanceBefore = await convertToCurrencyDecimals(weth.address, '123');
+        await weth.functions['mint(address,uint256)'](
+          paraswapLiquiditySwapAdapter.address,
+          adapterWethBalanceBefore
+        );
+        await weth.transfer(paraswapLiquiditySwapAdapter.address, adapterWethBalanceBefore);
+        const adapterZbuBalanceBefore = await convertToCurrencyDecimals(aave.address, '234');
+        await aave.functions['mint(address,uint256)'](
+          paraswapLiquiditySwapAdapter.address,
+          adapterZbuBalanceBefore
+        );
+        await aave.transfer(paraswapLiquiditySwapAdapter.address, adapterZbuBalanceBefore);
+
+        const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+        const aavePrice = await oracle.getAssetPrice(aave.address);
+        const expectedUsdcAmount = await convertToCurrencyDecimals(
+          aave.address,
+          new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+        );
+
+        await mockAugustus.expectSwap(
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          amountWETHtoSwap,
+          expectedUsdcAmount
+        );
+
+        // User will swap liquidity aEth to zUsdc
+        const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+        await aWETH
+          .connect(user.signer)
+          .approve(paraswapLiquiditySwapAdapter.address, amountWETHtoSwap);
+
+        const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+          weth.address,
+          aave.address,
+          amountWETHtoSwap,
+          expectedUsdcAmount,
+        ]);
+
+        await expect(
+          paraswapLiquiditySwapAdapter
+            .connect(user.signer)
+            .swapAndDeposit(
+              weth.address,
+              aave.address,
+              amountWETHtoSwap,
+              expectedUsdcAmount,
+              0,
+              mockAugustusCalldata,
+              mockAugustus.address,
+              {
+                amount: 0,
+                deadline: 0,
+                v: 0,
+                r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              }
+            )
+        )
+          .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+          .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+        const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+        const userzUsdcBalance = await aAave.balanceOf(userAddress);
+        const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+        expect(adapterWethBalance).to.be.eq(adapterWethBalanceBefore);
+        expect(adapterZbuBalance).to.be.eq(adapterZbuBalanceBefore);
+        expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+        expect(userAEthBalance).to.be.eq(userAEthBalanceBefore.sub(amountWETHtoSwap));
+      });
+    });
+
+    // describe('swapAndDeposit with borrowing', () => {
+    //   beforeEach(async () => {
+    //     const { users: [user], weth, aave, pool, deployer } = testEnv;
+    //     const userAddress = user.address;
+    //     const borrower = users[1].signer;
+    //     const borrowerAddress = users[1].address;
+
+    //     // Provide liquidity
+    //     const usdcAmount = await convertToCurrencyDecimals(aave.address, '20000');
+    //     await aave.functions['mint(address,uint256)'](deployer.address, usdcAmount);
+    //     await aave.approve(pool.address, usdcAmount);
+    //     await pool.deposit(aave.address, usdcAmount, deployer.address, 0);
+
+    //     const wethAmount = await convertToCurrencyDecimals(weth.address, '10000');
+    //     await weth.functions['mint(address,uint256)'](deployer.address, wethAmount);
+    //     await weth.approve(pool.address, wethAmount);
+    //     await pool.deposit(weth.address, wethAmount, deployer.address, 0);
+
+    //     // Make a deposit for user
+    //     const userWethAmount = await convertToCurrencyDecimals(weth.address, '100');
+    //     await weth.functions['mint(address,uint256)'](userAddress, userWethAmount);
+    //     await weth.approve(pool.address, userWethAmount);
+    //     await pool.deposit(weth.address, userWethAmount, userAddress, 0);
+
+    //     // Add borrowing
+    //     const collateralAmount = parseEther('10000000');
+    //     await aave.functions['mint(address,uint256)'](borrowerAddress, collateralAmount);
+    //     await aave.approve(pool.address, collateralAmount);
+    //     await pool.deposit(aave.address, collateralAmount, borrowerAddress, 0);
+    //     await pool
+    //       .connect(borrower)
+    //       .borrow(weth.address, parseEther('5000'), 2, 0, borrowerAddress);
+    //   });
+
+    //   it('should correctly swap tokens and deposit the out tokens in the pool', async () => {
+    //     const { users: [user], weth, oracle, aave, pool, aWETH, aAave } = testEnv;
+
+    //     const userAddress = user.address;
+
+    //     const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+    //     const aavePrice = await oracle.getAssetPrice(aave.address);
+    //     const expectedUsdcAmount = await convertToCurrencyDecimals(
+    //       aave.address,
+    //       new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+    //     );
+
+    //     await mockAugustus.expectSwap(
+    //       weth.address,
+    //       aave.address,
+    //       amountWETHtoSwap,
+    //       amountWETHtoSwap,
+    //       expectedUsdcAmount
+    //     );
+
+    //     const flashloanPremium = amountWETHtoSwap.mul(9).div(10000);
+    //     const flashloanTotal = amountWETHtoSwap.add(flashloanPremium);
+
+    //     // User will swap liquidity aEth to zUsdc
+    //     const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+    //     await aWETH.connect(user.signer).approve(paraswapLiquiditySwapAdapter.address, flashloanTotal);
+
+    //     const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+    //       weth.address,
+    //       aave.address,
+    //       amountWETHtoSwap,
+    //       expectedUsdcAmount,
+    //     ]);
+
+    //     const params = buildParaSwapLiquiditySwapParams(
+    //       aave.address,
+    //       expectedUsdcAmount,
+    //       0,
+    //       mockAugustusCalldata,
+    //       mockAugustus.address,
+    //       0,
+    //       0,
+    //       0,
+    //       '0x0000000000000000000000000000000000000000000000000000000000000000',
+    //       '0x0000000000000000000000000000000000000000000000000000000000000000'
+    //     );
+
+    //     await expect(
+    //       pool
+    //         .connect(user.signer)
+    //         .flashLoan(
+    //           paraswapLiquiditySwapAdapter.address,
+    //           [weth.address],
+    //           [amountWETHtoSwap],
+    //           [0],
+    //           userAddress,
+    //           params,
+    //           0
+    //         )
+    //     )
+    //       .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+    //       .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+    //     const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+    //     const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+    //     const userzUsdcBalance = await aAave.balanceOf(userAddress);
+    //     const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+    //     expect(adapterWethBalance).to.be.eq(Zero);
+    //     expect(adapterZbuBalance).to.be.eq(Zero);
+    //     expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+    //     expect(userAEthBalance).to.be.gt(userAEthBalanceBefore.sub(flashloanTotal));
+    //     expect(userAEthBalance).to.be.lt(
+    //       userAEthBalanceBefore.mul(10001).div(10000).sub(amountWETHtoSwap)
+    //     );
+    //   });
+
+    //   it('should correctly swap tokens using permit', async () => {
+    //     const { users: [user], weth, oracle, aave, pool, aWETH, aAave } = testEnv;
+
+    //     const userAddress = user.address;
+
+    //     const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+    //     const aavePrice = await oracle.getAssetPrice(aave.address);
+    //     const expectedUsdcAmount = await convertToCurrencyDecimals(
+    //       aave.address,
+    //       new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+    //     );
+
+    //     await mockAugustus.expectSwap(
+    //       weth.address,
+    //       aave.address,
+    //       amountWETHtoSwap,
+    //       amountWETHtoSwap,
+    //       expectedUsdcAmount
+    //     );
+
+    //     const flashloanPremium = amountWETHtoSwap.mul(9).div(10000);
+    //     const flashloanTotal = amountWETHtoSwap.add(flashloanPremium);
+
+    //     // User will swap liquidity aEth to zUsdc
+    //     const userAEthBalanceBefore = await aWETH.balanceOf(userAddress);
+
+    //     const chainId = hre.network.config.chainId || 31337;
+    //     const deadline = MAX_UINT_AMOUNT;
+    //     const nonce = (await aWETH._nonces(userAddress)).toNumber();
+    //     const msgParams = buildPermitParams(
+    //       chainId,
+    //       aWETH.address,
+    //       '1',
+    //       await aWETH.name(),
+    //       userAddress,
+    //       paraswapLiquiditySwapAdapter.address,
+    //       nonce,
+    //       deadline,
+    //       amountWETHtoSwap.toString()
+    //     );
+
+    //     const ownerPrivateKey = require('../../test-wallets.js').accounts[1].secretKey;
+    //     if (!ownerPrivateKey) {
+    //       throw new Error('INVALID_OWNER_PK');
+    //     }
+
+    //     const { v, r, s } = getSignatureFromTypedData(ownerPrivateKey, msgParams);
+
+    //     const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+    //       weth.address,
+    //       aave.address,
+    //       amountWETHtoSwap,
+    //       expectedUsdcAmount,
+    //     ]);
+
+    //     await expect(
+    //       paraswapLiquiditySwapAdapter
+    //         .connect(user.signer)
+    //         .swapAndDeposit(
+    //           weth.address,
+    //           aave.address,
+    //           amountWETHtoSwap,
+    //           expectedUsdcAmount,
+    //           0,
+    //           mockAugustusCalldata,
+    //           mockAugustus.address,
+    //           {
+    //             amount: amountWETHtoSwap,
+    //             deadline,
+    //             v,
+    //             r,
+    //             s,
+    //           }
+    //         )
+    //     )
+    //       .to.emit(paraswapLiquiditySwapAdapter, 'Swapped')
+    //       .withArgs(weth.address, aave.address, amountWETHtoSwap, expectedUsdcAmount);
+
+    //     const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+    //     const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+    //     const userzUsdcBalance = await aAave.balanceOf(userAddress);
+    //     const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+    //     expect(adapterWethBalance).to.be.eq(Zero);
+    //     expect(adapterZbuBalance).to.be.eq(Zero);
+    //     expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+    //     expect(userAEthBalance).to.be.gt(userAEthBalanceBefore.sub(amountWETHtoSwap));
+    //     expect(userAEthBalance).to.be.lt(
+    //       userAEthBalanceBefore.mul(10001).div(10000).sub(amountWETHtoSwap)
+    //     );
+    //   });
+
+    //   it('should correctly swap all the balance when using a bigger amount', async () => {
+    //     const { users: [user], weth, oracle, aave, pool, aAave, aWETH } = testEnv;
+
+    //     const userAddress = user.address;
+
+    //     const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+    //     const aavePrice = await oracle.getAssetPrice(aave.address);
+    //     const expectedUsdcAmount = await convertToCurrencyDecimals(
+    //       aave.address,
+    //       new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+    //     );
+
+    //     await mockAugustus.expectSwap(
+    //       weth.address,
+    //       aave.address,
+    //       amountWETHtoSwap.add(1),
+    //       amountWETHtoSwap.mul(10001).div(10000),
+    //       expectedUsdcAmount
+    //     );
+
+    //     // Remove other balance
+    //     const transferAmount = await convertToCurrencyDecimals(aWETH.address, '90');
+    //     await aWETH.connect(user.signer).transfer(users[1].address, transferAmount);
+
+    //     // User will swap liquidity aEth to zUsdc
+    //     const bigAmountToSwap = await convertToCurrencyDecimals(aWETH.address, '11');
+    //     await aWETH.connect(user.signer).approve(paraswapLiquiditySwapAdapter.address, bigAmountToSwap);
+
+    //     const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+    //       weth.address,
+    //       aave.address,
+    //       bigAmountToSwap,
+    //       expectedUsdcAmount,
+    //     ]);
+
+    //     await expect(
+    //       paraswapLiquiditySwapAdapter
+    //         .connect(user.signer)
+    //         .swapAndDeposit(
+    //           weth.address,
+    //           aave.address,
+    //           bigAmountToSwap,
+    //           expectedUsdcAmount,
+    //           4 + 2 * 32,
+    //           mockAugustusCalldata,
+    //           mockAugustus.address,
+    //           {
+    //             amount: 0,
+    //             deadline: 0,
+    //             v: 0,
+    //             r: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    //             s: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    //           }
+    //         )
+    //     ).to.emit(paraswapLiquiditySwapAdapter, 'Swapped');
+
+    //     const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+    //     const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+    //     const userzUsdcBalance = await aAave.balanceOf(userAddress);
+    //     const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+    //     expect(adapterWethBalance).to.be.eq(Zero);
+    //     expect(adapterZbuBalance).to.be.eq(Zero);
+    //     expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+    //     expect(userAEthBalance).to.be.eq(Zero);
+    //   });
+
+    //   it('should correctly swap all the balance when using permit', async () => {
+    //     const { users: [user], weth, oracle, aave, pool, aAave, aWETH } = testEnv;
+
+    //     const userAddress = user.address;
+
+    //     const amountWETHtoSwap = await convertToCurrencyDecimals(weth.address, '10');
+
+    //     const aavePrice = await oracle.getAssetPrice(aave.address);
+    //     const expectedUsdcAmount = await convertToCurrencyDecimals(
+    //       aave.address,
+    //       new BigNumber(amountWETHtoSwap.toString()).div(aavePrice.toString()).toFixed(0)
+    //     );
+
+    //     await mockAugustus.expectSwap(
+    //       weth.address,
+    //       aave.address,
+    //       amountWETHtoSwap.add(1),
+    //       amountWETHtoSwap.mul(10001).div(10000),
+    //       expectedUsdcAmount
+    //     );
+
+    //     // Remove other balance
+    //     const transferAmount = await convertToCurrencyDecimals(aWETH.address, '90');
+    //     await aWETH.connect(user.signer).transfer(users[1].address, transferAmount);
+
+    //     // User will swap liquidity aEth to zUsdc
+    //     const bigAmountToSwap = await convertToCurrencyDecimals(aWETH.address, '11');
+
+    //     const chainId = hre.network.config.chainId || 31337;
+    //     const deadline = MAX_UINT_AMOUNT;
+    //     const nonce = (await aWETH._nonces(userAddress)).toNumber();
+    //     const msgParams = buildPermitParams(
+    //       chainId,
+    //       aWETH.address,
+    //       '1',
+    //       await aWETH.name(),
+    //       userAddress,
+    //       paraswapLiquiditySwapAdapter.address,
+    //       nonce,
+    //       deadline,
+    //       bigAmountToSwap.toString()
+    //     );
+
+    //     const ownerPrivateKey = require('../../test-wallets.js').accounts[1].secretKey;
+    //     if (!ownerPrivateKey) {
+    //       throw new Error('INVALID_OWNER_PK');
+    //     }
+
+    //     const { v, r, s } = getSignatureFromTypedData(ownerPrivateKey, msgParams);
+
+    //     const mockAugustusCalldata = mockAugustus.interface.encodeFunctionData('swap', [
+    //       weth.address,
+    //       aave.address,
+    //       bigAmountToSwap,
+    //       expectedUsdcAmount,
+    //     ]);
+
+    //     await expect(
+    //       paraswapLiquiditySwapAdapter
+    //         .connect(user.signer)
+    //         .swapAndDeposit(
+    //           weth.address,
+    //           aave.address,
+    //           bigAmountToSwap,
+    //           expectedUsdcAmount,
+    //           4 + 2 * 32,
+    //           mockAugustusCalldata,
+    //           mockAugustus.address,
+    //           {
+    //             amount: bigAmountToSwap,
+    //             deadline,
+    //             v,
+    //             r,
+    //             s,
+    //           }
+    //         )
+    //     ).to.emit(paraswapLiquiditySwapAdapter, 'Swapped');
+
+    //     const adapterWethBalance = await weth.balanceOf(paraswapLiquiditySwapAdapter.address);
+    //     const adapterZbuBalance = await aave.balanceOf(paraswapLiquiditySwapAdapter.address);
+    //     const userzUsdcBalance = await aAave.balanceOf(userAddress);
+    //     const userAEthBalance = await aWETH.balanceOf(userAddress);
+
+    //     expect(adapterWethBalance).to.be.eq(Zero);
+    //     expect(adapterZbuBalance).to.be.eq(Zero);
+    //     expect(userzUsdcBalance).to.be.eq(expectedUsdcAmount);
+    //     expect(userAEthBalance).to.be.eq(Zero);
+    //   });
+    // });
+  });
+});


### PR DESCRIPTION
This PR implements the migration of ParaSwap integration contracts and their corresponding unit tests to the Aave V3 protocol. The integration enables efficient token swaps within the Aave protocol using ParaSwap's liquidity aggregation.

All contracts has been taken from Aave v2 old fork.
Clickup [task:](https://app.clickup.com/t/86a8uu84y)
